### PR TITLE
feat(feedback): add feedback command and update confirmation dialogs …

### DIFF
--- a/internal/cli/add.go
+++ b/internal/cli/add.go
@@ -105,7 +105,7 @@ func runAdd(cmd *cobra.Command, args []string) error {
 		fmt.Println("   Run 'skulto' and press 'p' to sync later")
 	}
 
-	fmt.Printf("\n\U0001F480 Repository %s added successfully!\n", source.ID)
+	fmt.Printf("\n🚀 Repository %s added successfully!\n", source.ID)
 
 	// Track telemetry event
 	skillCount := 0

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -59,6 +59,7 @@ func init() {
 	rootCmd.AddCommand(addCmd)
 	rootCmd.AddCommand(checkCmd)
 	rootCmd.AddCommand(favoritesCmd)
+	rootCmd.AddCommand(feedbackCmd)
 	rootCmd.AddCommand(infoCmd)
 	rootCmd.AddCommand(installCmd)
 	rootCmd.AddCommand(listCmd)

--- a/internal/cli/feedback.go
+++ b/internal/cli/feedback.go
@@ -1,0 +1,29 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/asteroid-belt/skulto/internal/constants"
+	"github.com/spf13/cobra"
+)
+
+var feedbackCmd = &cobra.Command{
+	Use:   "feedback",
+	Short: "Show how to provide feedback about Skulto",
+	Long: `Display the feedback URL where you can share your thoughts about Skulto.
+
+Your feedback helps us improve! Report bugs, request features, or just let us know
+how Skulto is working for you.`,
+	Args: cobra.NoArgs,
+	RunE: runFeedback,
+}
+
+func runFeedback(cmd *cobra.Command, args []string) error {
+	fmt.Println("We'd love to hear from you!")
+	fmt.Println()
+	fmt.Println("Share your feedback, report bugs, or request features:")
+	fmt.Printf("  %s\n", constants.FeedbackURL)
+	fmt.Println()
+	fmt.Println("Your feedback helps us improve Skulto.")
+	return nil
+}

--- a/internal/cli/tui.go
+++ b/internal/cli/tui.go
@@ -115,7 +115,7 @@ func runTUI(cmd *cobra.Command, args []string) error {
 		log.Println("\nTelemetry: OFF")
 	}
 
-	log.Println("\n\U0001F480 Launching Skulto TUI...")
+	log.Println("\n🚀 Launching Skulto TUI...")
 	return tui.RunWithIndexer(database, cfg, bgIndexer, telemetryClient)
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -1,0 +1,5 @@
+// Package constants provides application-wide constant values.
+package constants
+
+// FeedbackURL is the URL where users can provide feedback about Skulto.
+const FeedbackURL = "https://listenlabs.ai/s/3Q78n32D"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/asteroid-belt/skulto/internal/config"
+	"github.com/asteroid-belt/skulto/internal/constants"
 	"github.com/asteroid-belt/skulto/internal/db"
 	"github.com/asteroid-belt/skulto/internal/detect"
 	"github.com/asteroid-belt/skulto/internal/favorites"
@@ -236,7 +237,7 @@ func NewModel(database *db.DB, conf *config.Config) *Model {
 		installer:            inst,
 		installService:       instService,
 		newSkillDialog:       components.NewNewSkillDialog(),
-		quitConfirmDialog:    components.NewConfirmDialog("Quit Skulto?", "Are you sure you want to exit?"),
+		quitConfirmDialog:    newQuitDialog(),
 	}
 }
 
@@ -323,8 +324,15 @@ func NewModelWithIndexer(database *db.DB, conf *config.Config, indexer *search.B
 		ticker:               time.NewTicker(500 * time.Millisecond),
 		animTick:             0,
 		newSkillDialog:       components.NewNewSkillDialog(),
-		quitConfirmDialog:    components.NewConfirmDialog("Quit Skulto?", "Are you sure you want to exit?"),
+		quitConfirmDialog:    newQuitDialog(),
 	}
+}
+
+// newQuitDialog creates a quit confirmation dialog with feedback URL in footer.
+func newQuitDialog() *components.ConfirmDialog {
+	dialog := components.NewConfirmDialog("Quit Skulto?", "Are you sure you want to exit?")
+	dialog.SetFooter("Feedback? " + constants.FeedbackURL)
+	return dialog
 }
 
 // viewName returns a string name for a ViewType.

--- a/internal/tui/components/confirm.go
+++ b/internal/tui/components/confirm.go
@@ -9,7 +9,8 @@ import (
 type ConfirmDialog struct {
 	title    string
 	message  string
-	selected bool // false = no, true = yes
+	footer   string // optional footer text below buttons
+	selected bool   // false = no, true = yes
 }
 
 // NewConfirmDialog creates a new confirmation dialog.
@@ -39,6 +40,11 @@ func (c *ConfirmDialog) IsYesSelected() bool {
 // Toggle switches between Yes and No.
 func (c *ConfirmDialog) Toggle() {
 	c.selected = !c.selected
+}
+
+// SetFooter sets optional footer text displayed below the buttons.
+func (c *ConfirmDialog) SetFooter(footer string) {
+	c.footer = footer
 }
 
 // View renders the confirmation dialog.
@@ -72,6 +78,21 @@ func (c *ConfirmDialog) View() string {
 		" ]",
 	)
 
+	// Build content elements
+	elements := []string{
+		lipgloss.NewStyle().Bold(true).Foreground(theme.Current.Text).Render(c.title),
+		"",
+		c.message,
+		"",
+		buttons,
+	}
+
+	// Add footer if set
+	if c.footer != "" {
+		footerStyle := lipgloss.NewStyle().Foreground(theme.Current.TextMuted)
+		elements = append(elements, "", footerStyle.Render(c.footer))
+	}
+
 	dialog := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(theme.Current.Primary).
@@ -79,11 +100,7 @@ func (c *ConfirmDialog) View() string {
 		Render(
 			lipgloss.JoinVertical(
 				lipgloss.Center,
-				lipgloss.NewStyle().Bold(true).Foreground(theme.Current.Text).Render(c.title),
-				"",
-				c.message,
-				"",
-				buttons,
+				elements...,
 			),
 		)
 

--- a/internal/tui/views/settings.go
+++ b/internal/tui/views/settings.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/asteroid-belt/skulto/internal/config"
+	"github.com/asteroid-belt/skulto/internal/constants"
 	"github.com/asteroid-belt/skulto/internal/db"
 	"github.com/asteroid-belt/skulto/internal/installer"
 	"github.com/asteroid-belt/skulto/internal/models"
@@ -479,12 +480,16 @@ func (sv *SettingsView) renderFooter() string {
 		telemetryLines = telemetryStyle.Render("Telemetry: OFF")
 	}
 
+	// Feedback link
+	feedbackStyle := lipgloss.NewStyle().Foreground(theme.Current.TextMuted)
+	feedbackLine := feedbackStyle.Render(fmt.Sprintf("Feedback? %s", constants.FeedbackURL))
+
 	// Navigation line
 	navStyle := lipgloss.NewStyle().Foreground(theme.Current.TextMuted).
 		PaddingTop(1)
 	navLine := navStyle.Render(fmt.Sprintf("%s | %s | %s", positionStr, sectionStr, helpStr))
 
-	return telemetryLines + "\n" + navLine
+	return telemetryLines + "\n\n" + feedbackLine + "\n" + navLine
 }
 
 // HandleSettingsLoaded handles the SettingsLoadedMsg


### PR DESCRIPTION
…with feedback URL

Introduce `feedbackCmd` to allow users to easily provide feedback about Skulto. Modified existing confirmation dialogs to include a footer with the feedback URL, enhancing user engagement and making it easier for users to share their thoughts and suggestions. Updated messages to include emoji for improved user experience.

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project style guidelines
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`make test`)
- [ ] The linter passes (`make lint`)
- [ ] I have updated documentation if needed

## Related Issues

Closes #(issue number)
