### PR TITLE
feat(sync-manifest): Implement Skulto sync manifest support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-integration test-race test-race-integration test-coverage lint clean install dev run help deps fmt scrape ship-it release release-all
+.PHONY: all build fresh test test-integration test-race test-race-integration test-coverage lint clean install dev run help deps fmt scrape ship-it release release-all
 
 # Variables
 BINARY_NAME=skulto
@@ -38,6 +38,18 @@ build-mcp:
 
 ## build-all: Build all binaries (skulto and skulto-mcp)
 build-all: build build-mcp
+
+## fresh: Clean build cache and rebuild both binaries from scratch
+fresh:
+	@echo "Cleaning build cache..."
+	@rm -rf $(BUILD_DIR)
+	$(GO) clean -cache
+	@echo "Rebuilding $(BINARY_NAME) from scratch..."
+	@mkdir -p $(BUILD_DIR)
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) $(CMD_DIR)
+	@echo "Rebuilding skulto-mcp from scratch..."
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GOFLAGS) $(LDFLAGS) -o $(BUILD_DIR)/skulto-mcp $(CMD_MCP_DIR)
+	@echo "✅ Fresh build complete: $(BUILD_DIR)/$(BINARY_NAME) + $(BUILD_DIR)/skulto-mcp"
 
 ## release: Build all artifacts for specified platform (GOOS=linux|darwin GOARCH=amd64|arm64)
 release:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -67,7 +67,9 @@ func init() {
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(pullCmd)
 	rootCmd.AddCommand(removeCmd)
+	rootCmd.AddCommand(saveCmd)
 	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(syncCmd)
 	rootCmd.AddCommand(uninstallCmd)
 	rootCmd.AddCommand(updateCmd)
 }

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -25,10 +25,14 @@ var (
 )
 
 var installCmd = &cobra.Command{
-	Use:     "install <slug|url>",
+	Use:     "install [slug|url]",
 	Aliases: []string{"i"},
-	Short:   "Install a skill to AI tool directories (alias: i)",
+	Short:   "Install skill(s) to AI tool directories (alias: i)",
 	Long: `Install a skill by slug or from a repository URL.
+
+No arguments:
+  Reads skulto.json and installs all listed skills.
+  Equivalent to 'skulto sync'.
 
 The install command creates symlinks in your AI tool directories,
 making skills available to Claude, Cursor, Windsurf, and other tools.
@@ -72,8 +76,11 @@ Examples:
   skulto install https://github.com/owner/skills
 
   # Install from short format
-  skulto install owner/skills`,
-	Args: cobra.ExactArgs(1),
+  skulto install owner/skills
+
+  # Install all from manifest (no arguments)
+  skulto install`,
+	Args: cobra.RangeArgs(0, 1),
 	RunE: runInstall,
 }
 
@@ -87,6 +94,11 @@ func init() {
 }
 
 func runInstall(cmd *cobra.Command, args []string) error {
+	// No arguments: delegate to sync (install from skulto.json)
+	if len(args) == 0 {
+		return runSync(cmd, args)
+	}
+
 	ctx := cmd.Context()
 	input := args[0]
 

--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -28,9 +28,14 @@ func TestInstallCmd_Structure(t *testing.T) {
 	assert.Equal(t, "y", yFlag.Shorthand)
 }
 
-func TestInstallCmd_RequiresArg(t *testing.T) {
+func TestInstallCmd_AcceptsNoArgs(t *testing.T) {
 	err := installCmd.Args(installCmd, []string{})
-	assert.Error(t, err, "Should require at least 1 argument")
+	assert.NoError(t, err, "Should accept 0 arguments (delegates to sync)")
+}
+
+func TestInstallCmd_RejectsTwoArgs(t *testing.T) {
+	err := installCmd.Args(installCmd, []string{"a", "b"})
+	assert.Error(t, err, "Should reject more than 1 argument")
 }
 
 func TestInstallCmd_AcceptsArg(t *testing.T) {

--- a/internal/cli/save.go
+++ b/internal/cli/save.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/asteroid-belt/skulto/internal/config"
+	"github.com/asteroid-belt/skulto/internal/db"
+	"github.com/asteroid-belt/skulto/internal/manifest"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var saveCmd = &cobra.Command{
+	Use:   "save",
+	Short: "Save project skills to skulto.json",
+	Long: `Save currently installed project-scope skills to skulto.json.
+
+This creates a manifest file that can be checked into version control,
+allowing teammates to sync the same skills with 'skulto sync'.
+
+Only project-scope installations for the current directory are saved.
+Local-only skills (without a source repository) are skipped.
+
+Examples:
+  skulto save
+  git add skulto.json && git commit -m "chore: add skulto manifest"`,
+	Args: cobra.NoArgs,
+	RunE: runSave,
+}
+
+func runSave(cmd *cobra.Command, args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return trackCLIError("save", fmt.Errorf("get working directory: %w", err))
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return trackCLIError("save", fmt.Errorf("load config: %w", err))
+	}
+
+	paths := config.GetPaths(cfg)
+	database, err := db.New(db.DefaultConfig(paths.Database))
+	if err != nil {
+		return trackCLIError("save", fmt.Errorf("initialize database: %w", err))
+	}
+	defer func() { _ = database.Close() }()
+
+	installations, err := database.GetProjectInstallations(cwd)
+	if err != nil {
+		return trackCLIError("save", fmt.Errorf("query installations: %w", err))
+	}
+
+	if len(installations) == 0 {
+		fmt.Println("No project-scope skills installed for this directory.")
+		fmt.Println()
+		fmt.Println("Install skills with project scope first:")
+		fmt.Println("  skulto install <slug> -s project")
+		return nil
+	}
+
+	mf := manifest.New()
+	skippedLocal := 0
+	seen := make(map[string]bool)
+
+	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+
+	for _, inst := range installations {
+		if seen[inst.SkillID] {
+			continue
+		}
+		seen[inst.SkillID] = true
+
+		skill, err := database.GetSkill(inst.SkillID)
+		if err != nil || skill == nil {
+			continue
+		}
+
+		if skill.SourceID == nil || skill.Source == nil {
+			skippedLocal++
+			fmt.Printf("  %s %s (local-only, no source repository)\n",
+				warnStyle.Render("SKIP"), skill.Slug)
+			continue
+		}
+
+		mf.Skills[skill.Slug] = skill.Source.FullName
+	}
+
+	if err := manifest.Write(cwd, mf); err != nil {
+		return trackCLIError("save", fmt.Errorf("write manifest: %w", err))
+	}
+
+	fmt.Println()
+	successStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)
+	slugStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("141"))
+	sourceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+
+	fmt.Printf("%s Saved to %s\n\n", successStyle.Render("SAVED"), manifest.FileName)
+
+	for _, slug := range mf.SortedSlugs() {
+		source := mf.Skills[slug]
+		fmt.Printf("  %s  %s\n", slugStyle.Render(slug), sourceStyle.Render(source))
+	}
+
+	fmt.Printf("\n%d skill(s) saved", mf.SkillCount())
+	if skippedLocal > 0 {
+		fmt.Printf(", %d local-only skill(s) skipped", skippedLocal)
+	}
+	fmt.Println()
+
+	telemetryClient.TrackManifestSaved(mf.SkillCount(), "cli")
+
+	return nil
+}

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -1,0 +1,322 @@
+package cli
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/asteroid-belt/skulto/internal/cli/prompts"
+	"github.com/asteroid-belt/skulto/internal/config"
+	"github.com/asteroid-belt/skulto/internal/db"
+	"github.com/asteroid-belt/skulto/internal/installer"
+	"github.com/asteroid-belt/skulto/internal/manifest"
+	"github.com/asteroid-belt/skulto/internal/models"
+	"github.com/asteroid-belt/skulto/internal/scraper"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Install skills from skulto.json",
+	Long: `Install all skills listed in skulto.json.
+
+Reads the project manifest and installs any skills not already present.
+If a source repository is not in your database, you will be prompted to add it.
+
+This is equivalent to running 'skulto install' with no arguments.
+
+Examples:
+  skulto sync
+  skulto install`,
+	Args: cobra.NoArgs,
+	RunE: runSync,
+}
+
+func runSync(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return trackCLIError("sync", fmt.Errorf("get working directory: %w", err))
+	}
+
+	mf, err := manifest.Read(cwd)
+	if err != nil {
+		return trackCLIError("sync", fmt.Errorf("read manifest: %w", err))
+	}
+	if mf == nil {
+		fmt.Println("No skulto.json found in the current directory.")
+		fmt.Println()
+		fmt.Println("Create one with:")
+		fmt.Println("  skulto save")
+		return nil
+	}
+
+	if mf.SkillCount() == 0 {
+		fmt.Println("skulto.json has no skills listed.")
+		return nil
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return trackCLIError("sync", fmt.Errorf("load config: %w", err))
+	}
+
+	paths := config.GetPaths(cfg)
+	database, err := db.New(db.DefaultConfig(paths.Database))
+	if err != nil {
+		return trackCLIError("sync", fmt.Errorf("initialize database: %w", err))
+	}
+	defer func() { _ = database.Close() }()
+
+	service := installer.NewInstallService(database, cfg, telemetryClient)
+
+	headerStyle := lipgloss.NewStyle().Bold(true)
+	fmt.Printf("%s (%d skills)\n", headerStyle.Render("SYNCING from skulto.json"), mf.SkillCount())
+	fmt.Println(strings.Repeat("\u2500", 50))
+
+	// Step 1: Group skills by source
+	sourceSkills := make(map[string][]string)
+	for slug, source := range mf.Skills {
+		sourceSkills[source] = append(sourceSkills[source], slug)
+	}
+
+	// Step 2: Ensure all sources exist
+	skippedSources := make(map[string]bool)
+	reader := bufio.NewReader(os.Stdin)
+
+	for sourceName := range sourceSkills {
+		source, err := database.GetSource(sourceName)
+		if err != nil || source == nil {
+			fmt.Printf("\nSource '%s' not found in your database.\n", sourceName)
+			fmt.Print("Add it? [y/N] ")
+
+			answer, _ := reader.ReadString('\n')
+			answer = strings.TrimSpace(strings.ToLower(answer))
+
+			if answer == "y" || answer == "yes" {
+				fmt.Printf("Adding %s...\n", sourceName)
+
+				parts := strings.SplitN(sourceName, "/", 2)
+				if len(parts) != 2 {
+					fmt.Printf("  Invalid source format: %s (expected owner/repo)\n", sourceName)
+					skippedSources[sourceName] = true
+					continue
+				}
+
+				scraperCfg := scraper.ScraperConfig{
+					Token:        cfg.GitHub.Token,
+					DataDir:      cfg.BaseDir,
+					RepoCacheTTL: cfg.GitHub.RepoCacheTTL,
+					UseGitClone:  cfg.GitHub.UseGitClone,
+				}
+				sc := scraper.NewScraperWithConfig(scraperCfg, database)
+
+				if _, err := sc.ScrapeRepository(ctx, parts[0], parts[1]); err != nil {
+					fmt.Printf("  Failed to add source: %v\n", err)
+					skippedSources[sourceName] = true
+					continue
+				}
+				fmt.Printf("  Added %s successfully.\n", sourceName)
+			} else {
+				fmt.Printf("  Skipping all skills from %s\n", sourceName)
+				skippedSources[sourceName] = true
+			}
+		}
+	}
+
+	// Step 3: Resolve skills
+	var skillsToInstall []*models.Skill
+	var skippedSkills int
+
+	warnStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
+
+	for _, slug := range mf.SortedSlugs() {
+		sourceName := mf.Skills[slug]
+
+		if skippedSources[sourceName] {
+			skippedSkills++
+			continue
+		}
+
+		skill, err := database.GetSkillBySlug(slug)
+		if err != nil || skill == nil {
+			fmt.Printf("  %s Skill '%s' not found in database\n", warnStyle.Render("WARN"), slug)
+			skippedSkills++
+			continue
+		}
+
+		if skill.Source != nil && skill.Source.FullName != sourceName {
+			fmt.Printf("  %s Skill '%s' found but from different source (%s, expected %s)\n",
+				warnStyle.Render("WARN"), slug, skill.Source.FullName, sourceName)
+			skippedSkills++
+			continue
+		}
+
+		skillsToInstall = append(skillsToInstall, skill)
+	}
+
+	if len(skillsToInstall) == 0 {
+		fmt.Println("\nNo skills to install.")
+		if skippedSkills > 0 {
+			fmt.Printf("(%d skill(s) skipped)\n", skippedSkills)
+		}
+		return nil
+	}
+
+	// Step 4: Platform and scope selection
+	fmt.Printf("\n%d skill(s) to install. Select where to install them:\n\n", len(skillsToInstall))
+
+	opts, err := selectSyncPlatformsAndScope(ctx, service)
+	if err != nil {
+		return trackCLIError("sync", err)
+	}
+	if opts == nil {
+		fmt.Println("Cancelled.")
+		return nil
+	}
+
+	// Step 5: Install skills
+	fmt.Println()
+	fmt.Println(strings.Repeat("\u2500", 50))
+
+	var installed, skipped, errored int
+	successStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+	skipStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	errorStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+
+	skipAll := false
+
+	for _, skill := range skillsToInstall {
+		locations, _ := service.GetInstallLocations(ctx, skill.Slug)
+		allInstalled := syncIsInstalledAtAll(locations, opts.Platforms, opts.Scopes)
+
+		if allInstalled {
+			fmt.Printf("  %s %s (already installed)\n", skipStyle.Render("o"), skill.Slug)
+			skipped++
+			continue
+		}
+
+		if len(locations) > 0 && !skipAll {
+			fmt.Printf("\n  '%s' is already installed at some locations.\n", skill.Slug)
+			fmt.Print("  Also install to your selected locations? [y/N/s(kip all)] ")
+
+			answer, _ := reader.ReadString('\n')
+			answer = strings.TrimSpace(strings.ToLower(answer))
+
+			if answer == "s" {
+				skipAll = true
+				fmt.Printf("  %s %s (skipped)\n", skipStyle.Render("o"), skill.Slug)
+				skipped++
+				continue
+			}
+			if answer != "y" && answer != "yes" {
+				fmt.Printf("  %s %s (skipped)\n", skipStyle.Render("o"), skill.Slug)
+				skipped++
+				continue
+			}
+		}
+
+		_, err := service.Install(ctx, skill.Slug, *opts)
+		if err != nil {
+			fmt.Printf("  %s %s: %v\n", errorStyle.Render("x"), skill.Slug, err)
+			errored++
+			continue
+		}
+
+		fmt.Printf("  %s %s\n", successStyle.Render("v"), skill.Slug)
+		installed++
+	}
+
+	// Summary
+	fmt.Println()
+	fmt.Println(strings.Repeat("\u2500", 50))
+	fmt.Printf("Done! Installed: %d, Skipped: %d", installed, skipped)
+	if errored > 0 {
+		fmt.Printf(", Errors: %d", errored)
+	}
+	if skippedSkills > 0 {
+		fmt.Printf(", Not found: %d", skippedSkills)
+	}
+	fmt.Println()
+
+	telemetryClient.TrackManifestSynced(mf.SkillCount(), installed, skipped)
+
+	return nil
+}
+
+// selectSyncPlatformsAndScope runs the platform and scope selection prompts for sync.
+func selectSyncPlatformsAndScope(ctx context.Context, service *installer.InstallService) (*installer.InstallOptions, error) {
+	platforms, err := service.DetectPlatforms(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("detect platforms: %w", err)
+	}
+
+	if !isInteractive() {
+		// Non-interactive: use detected platforms with global scope
+		var selected []string
+		for _, p := range platforms {
+			if p.Detected {
+				selected = append(selected, p.ID)
+			}
+		}
+		if len(selected) == 0 {
+			return nil, fmt.Errorf("no platforms detected, use interactive mode")
+		}
+		return &installer.InstallOptions{
+			Platforms: selected,
+			Scopes:    []installer.InstallScope{installer.ScopeGlobal},
+			Confirm:   true,
+		}, nil
+	}
+
+	result, err := prompts.RunGroupedPlatformSelector(platforms, nil, nil)
+	if err != nil {
+		return nil, fmt.Errorf("platform selection: %w", err)
+	}
+
+	if len(result.Selected) == 0 {
+		return nil, nil
+	}
+
+	scopeStrs, err := prompts.RunScopeSelector(nil)
+	if err != nil {
+		return nil, fmt.Errorf("scope selection: %w", err)
+	}
+	scopes := prompts.ParseScopeStrings(scopeStrs)
+	if len(scopes) == 0 {
+		scopes = []installer.InstallScope{installer.ScopeGlobal}
+	}
+
+	return &installer.InstallOptions{
+		Platforms: result.Selected,
+		Scopes:    scopes,
+		Confirm:   true,
+	}, nil
+}
+
+// syncIsInstalledAtAll checks if a skill is installed at all selected platform+scope combinations.
+func syncIsInstalledAtAll(
+	existing []installer.InstallLocation,
+	platforms []string,
+	scopes []installer.InstallScope,
+) bool {
+	for _, p := range platforms {
+		for _, s := range scopes {
+			found := false
+			for _, loc := range existing {
+				if string(loc.Platform) == p && loc.Scope == s {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/db/skill_installations.go
+++ b/internal/db/skill_installations.go
@@ -57,6 +57,15 @@ func (db *DB) GetAllInstallations() ([]models.SkillInstallation, error) {
 	return installations, err
 }
 
+// GetProjectInstallations returns all project-scope installations for a specific base path.
+// Used by the manifest save command to find which skills are installed for the current project.
+func (db *DB) GetProjectInstallations(basePath string) ([]models.SkillInstallation, error) {
+	var installations []models.SkillInstallation
+	err := db.Where("scope = ? AND base_path = ?", "project", basePath).
+		Find(&installations).Error
+	return installations, err
+}
+
 // GetLastInstallLocations returns the platform+scope pairs from the most recent
 // install event. An "install event" is a group of installations sharing the same
 // installed_at timestamp (i.e. all locations chosen in one dialog confirmation).

--- a/internal/db/skills.go
+++ b/internal/db/skills.go
@@ -164,10 +164,10 @@ func (db *DB) GetSkill(id string) (*models.Skill, error) {
 	return &skill, nil
 }
 
-// GetSkillBySlug retrieves a skill by slug.
+// GetSkillBySlug retrieves a skill by slug with its source and tags.
 func (db *DB) GetSkillBySlug(slug string) (*models.Skill, error) {
 	var skill models.Skill
-	err := db.Preload("Tags").First(&skill, "slug = ?", slug).Error
+	err := db.Joins("Source").Preload("Tags").First(&skill, "skills.slug = ?", slug).Error
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return nil, nil

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -98,6 +98,28 @@ func New() *ManifestFile {
 	}
 }
 
+// SkillEntry represents a skill eligible for inclusion in a manifest.
+type SkillEntry struct {
+	Slug       string
+	SourceName string // "owner/repo" format
+	LocalOnly  bool   // true if no source repository
+}
+
+// BuildFromSkills creates a manifest from skill entries, skipping local-only skills.
+// Returns the manifest and the count of skipped local-only skills.
+func BuildFromSkills(entries []SkillEntry) (*ManifestFile, int) {
+	mf := New()
+	skippedLocal := 0
+	for _, e := range entries {
+		if e.LocalOnly {
+			skippedLocal++
+			continue
+		}
+		mf.Skills[e.Slug] = e.SourceName
+	}
+	return mf, skippedLocal
+}
+
 // SkillCount returns the number of skills in the manifest.
 func (mf *ManifestFile) SkillCount() int {
 	return len(mf.Skills)

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -1,0 +1,114 @@
+package manifest
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+const (
+	// FileName is the manifest file name.
+	FileName = "skulto.json"
+
+	// CurrentVersion is the current manifest format version.
+	CurrentVersion = 1
+)
+
+// ManifestFile is the JSON structure of skulto.json.
+type ManifestFile struct {
+	Version int               `json:"version"`
+	Skills  map[string]string `json:"skills"` // slug -> "owner/repo"
+}
+
+// Read reads a manifest from the given directory.
+// Returns nil, nil if the file does not exist.
+func Read(dir string) (*ManifestFile, error) {
+	p := Path(dir)
+
+	data, err := os.ReadFile(p)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	var mf ManifestFile
+	if err := json.Unmarshal(data, &mf); err != nil {
+		return nil, fmt.Errorf("parse manifest: %w", err)
+	}
+
+	if mf.Skills == nil {
+		mf.Skills = make(map[string]string)
+	}
+
+	return &mf, nil
+}
+
+// Write writes a manifest to the given directory using atomic file operations.
+func Write(dir string, mf *ManifestFile) error {
+	if mf.Version == 0 {
+		mf.Version = CurrentVersion
+	}
+	if mf.Skills == nil {
+		mf.Skills = make(map[string]string)
+	}
+
+	data, err := json.MarshalIndent(mf, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+
+	// Append trailing newline
+	data = append(data, '\n')
+
+	p := Path(dir)
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return fmt.Errorf("create directory: %w", err)
+	}
+
+	// Atomic write: temp file + rename
+	tmpPath := p + ".tmp"
+	if err := os.WriteFile(tmpPath, data, 0644); err != nil {
+		return fmt.Errorf("write temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpPath, p); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename manifest: %w", err)
+	}
+
+	return nil
+}
+
+// Path returns the full path to skulto.json in the given directory.
+func Path(dir string) string {
+	return filepath.Join(dir, FileName)
+}
+
+// New creates a new empty manifest.
+func New() *ManifestFile {
+	return &ManifestFile{
+		Version: CurrentVersion,
+		Skills:  make(map[string]string),
+	}
+}
+
+// SkillCount returns the number of skills in the manifest.
+func (mf *ManifestFile) SkillCount() int {
+	return len(mf.Skills)
+}
+
+// SortedSlugs returns skill slugs in alphabetical order.
+func (mf *ManifestFile) SortedSlugs() []string {
+	slugs := make([]string, 0, len(mf.Skills))
+	for slug := range mf.Skills {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
+}

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -1,0 +1,198 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRead_FileExists(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a valid manifest
+	original := &ManifestFile{
+		Version: 1,
+		Skills: map[string]string{
+			"teach":     "asteroid-belt/skills",
+			"superplan": "asteroid-belt/skills",
+		},
+	}
+	if err := Write(dir, original); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Read it back
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Read returned nil")
+	}
+	if got.Version != 1 {
+		t.Errorf("Version = %d, want 1", got.Version)
+	}
+	if len(got.Skills) != 2 {
+		t.Errorf("Skills count = %d, want 2", len(got.Skills))
+	}
+	if got.Skills["teach"] != "asteroid-belt/skills" {
+		t.Errorf("Skills[teach] = %q, want %q", got.Skills["teach"], "asteroid-belt/skills")
+	}
+}
+
+func TestRead_FileNotExists(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Read returned non-nil for missing file: %+v", got)
+	}
+}
+
+func TestRead_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, FileName)
+
+	if err := os.WriteFile(p, []byte("not json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Read(dir)
+	if err == nil {
+		t.Fatal("Read should return error for invalid JSON")
+	}
+}
+
+func TestRead_EmptySkills(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, FileName)
+
+	if err := os.WriteFile(p, []byte(`{"version": 1}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Skills == nil {
+		t.Fatal("Skills should be initialized to empty map, not nil")
+	}
+}
+
+func TestWrite_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	mf := &ManifestFile{
+		Version: 1,
+		Skills: map[string]string{
+			"docker-expert": "vercel/skills",
+		},
+	}
+	if err := Write(dir, mf); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Verify file exists
+	p := Path(dir)
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		t.Fatalf("File not created at %s", p)
+	}
+
+	// Read raw contents to verify JSON structure
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if content[len(content)-1] != '\n' {
+		t.Error("File should end with newline")
+	}
+}
+
+func TestWrite_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+
+	mf := &ManifestFile{
+		Version: 1,
+		Skills: map[string]string{
+			"b-skill": "owner/repo-b",
+			"a-skill": "owner/repo-a",
+		},
+	}
+
+	// Write twice
+	if err := Write(dir, mf); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	data1, _ := os.ReadFile(Path(dir))
+
+	if err := Write(dir, mf); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+	data2, _ := os.ReadFile(Path(dir))
+
+	if string(data1) != string(data2) {
+		t.Error("Two writes produced different output (not idempotent)")
+	}
+}
+
+func TestWrite_SetsDefaultVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	mf := &ManifestFile{
+		Skills: map[string]string{"test": "owner/repo"},
+	}
+	if err := Write(dir, mf); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, _ := Read(dir)
+	if got.Version != CurrentVersion {
+		t.Errorf("Version = %d, want %d", got.Version, CurrentVersion)
+	}
+}
+
+func TestPath(t *testing.T) {
+	got := Path("/home/user/project")
+	want := filepath.Join("/home/user/project", FileName)
+	if got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+}
+
+func TestNew(t *testing.T) {
+	mf := New()
+	if mf.Version != CurrentVersion {
+		t.Errorf("Version = %d, want %d", mf.Version, CurrentVersion)
+	}
+	if mf.Skills == nil {
+		t.Error("Skills should not be nil")
+	}
+	if len(mf.Skills) != 0 {
+		t.Error("Skills should be empty")
+	}
+}
+
+func TestSortedSlugs(t *testing.T) {
+	mf := &ManifestFile{
+		Skills: map[string]string{
+			"charlie": "o/r",
+			"alpha":   "o/r",
+			"bravo":   "o/r",
+		},
+	}
+	got := mf.SortedSlugs()
+	want := []string{"alpha", "bravo", "charlie"}
+	if len(got) != len(want) {
+		t.Fatalf("len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("SortedSlugs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -114,6 +114,11 @@ func (m *mockTelemetryClient) TrackMCPToolCalled(toolName string, durationMs int
 	m.Track(telemetry.EventMCPToolCalled, map[string]interface{}{"tool_name": toolName, "success": success})
 }
 
+// Manifest events
+func (m *mockTelemetryClient) TrackManifestSaved(skillCount int, source string) {}
+func (m *mockTelemetryClient) TrackManifestSynced(totalSkills, installedCount, skippedCount int) {
+}
+
 func (m *mockTelemetryClient) getEvents() []mockEvent {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -78,6 +78,10 @@ type Client interface {
 
 	// MCP events
 	TrackMCPToolCalled(toolName string, durationMs int64, success bool)
+
+	// Manifest events
+	TrackManifestSaved(skillCount int, source string)
+	TrackManifestSynced(totalSkills, installedCount, skippedCount int)
 }
 
 // posthogClient wraps the PostHog SDK.

--- a/internal/telemetry/events.go
+++ b/internal/telemetry/events.go
@@ -73,6 +73,12 @@ const (
 	EventMCPToolCalled = "mcp_tool_called" // Track each MCP tool invocation
 )
 
+// Event names - Manifest
+const (
+	EventManifestSaved  = "manifest_saved"
+	EventManifestSynced = "manifest_synced"
+)
+
 // Version is set at compile time via ldflags.
 var Version string
 
@@ -476,6 +482,25 @@ func (c *posthogClient) TrackMCPToolCalled(toolName string, durationMs int64, su
 	c.Track(EventMCPToolCalled, props)
 }
 
+// --- Manifest Tracking Methods ---
+
+// TrackManifestSaved tracks when a manifest file is saved.
+func (c *posthogClient) TrackManifestSaved(skillCount int, source string) {
+	props := baseProperties()
+	props["skill_count"] = skillCount
+	props["source"] = source // "cli" or "tui"
+	c.Track(EventManifestSaved, props)
+}
+
+// TrackManifestSynced tracks when skills are synced from a manifest.
+func (c *posthogClient) TrackManifestSynced(totalSkills, installedCount, skippedCount int) {
+	props := baseProperties()
+	props["total_skills"] = totalSkills
+	props["installed_count"] = installedCount
+	props["skipped_count"] = skippedCount
+	c.Track(EventManifestSynced, props)
+}
+
 func (c *noopClient) TrackSkillsDiscovered(count int, scopeGlobal, scopeProject bool) {}
 func (c *noopClient) TrackSkillIngested(skillName, scope string)                      {}
 
@@ -487,3 +512,5 @@ func (c *noopClient) TrackStatsViewed()                                         
 func (c *noopClient) TrackRecentSkillsViewed(count int)                                  {}
 func (c *noopClient) TrackInstalledSkillsChecked(count int)                              {}
 func (c *noopClient) TrackMCPToolCalled(toolName string, durationMs int64, success bool) {}
+func (c *noopClient) TrackManifestSaved(skillCount int, source string)                   {}
+func (c *noopClient) TrackManifestSynced(totalSkills, installedCount, skippedCount int)  {}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -189,6 +189,9 @@ type (
 		count int
 		err   error
 	}
+
+	// statusClearMsg clears the transient status message in the home view footer
+	statusClearMsg struct{}
 )
 
 // NewModel creates a new TUI model.
@@ -1211,8 +1214,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case manifestSavedMsg:
 		if msg.err != nil {
 			m.setError(msg.err, "manifest_save")
+			m.homeView.SetStatusMessage("✗ Save failed")
+		} else {
+			m.homeView.SetStatusMessage(fmt.Sprintf("✓ Saved %d skill(s) to skulto.json", msg.count))
 		}
-		// Manifest saved successfully - no additional UI update needed
+		cmds = append(cmds, tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+			return statusClearMsg{}
+		}))
+
+	case statusClearMsg:
+		m.homeView.ClearStatusMessage()
 
 	case ingestCompleteMsg:
 		if msg.err != nil {

--- a/internal/tui/views/home.go
+++ b/internal/tui/views/home.go
@@ -26,6 +26,7 @@ const (
 	HomeActionSettings
 	HomeActionSelectTag
 	HomeActionSelectSkill
+	HomeActionSave
 )
 
 // Home view layout constants.
@@ -277,6 +278,9 @@ func (hv *HomeView) Update(key string) HomeAction {
 
 	case "s":
 		return HomeActionSettings
+
+	case "S":
+		return HomeActionSave
 
 	case "enter":
 		// Check if tag is selected first
@@ -531,7 +535,7 @@ func (hv *HomeView) renderWelcome() string {
 
 	return welcomeStyle.Render("Welcome to SKULTO") + "\n" +
 		msgStyle.Render(fmt.Sprintf("/ (search) • ↑↓ (nav) • %s • p (pull) • q (quit)", manageText)) + "\n" +
-		secondaryStyle.Render("a (add repo) • s (settings) • n (new skill) • ? (help)")
+		secondaryStyle.Render("a (add repo) • s (settings) • S (save) • n (new skill) • ? (help)")
 }
 
 // renderRecentSkillsWithLimit renders recent skills with scrolling support.
@@ -985,6 +989,7 @@ func (hv *HomeView) GetKeyboardCommands() ViewCommands {
 			{Key: "p", Description: "Pull latest from seed repositories"},
 			{Key: "s", Description: "Open settings"},
 			{Key: "n", Description: "New skill - create a skill from a prompt"},
+			{Key: "S", Description: "Save project skills to skulto.json"},
 		},
 	}
 }

--- a/internal/tui/views/home.go
+++ b/internal/tui/views/home.go
@@ -87,6 +87,9 @@ type HomeView struct {
 
 	// Discovery badge count
 	discoveryCount int64
+
+	// Transient status message (shown in footer center)
+	statusMessage string
 }
 
 // NewHomeView creates a new home view.
@@ -167,6 +170,16 @@ func (hv *HomeView) SetDiscoveryCount(count int64) {
 // GetDiscoveryCount returns the count of undismissed discovered skills.
 func (hv *HomeView) GetDiscoveryCount() int64 {
 	return hv.discoveryCount
+}
+
+// SetStatusMessage sets a transient status message to display in the footer.
+func (hv *HomeView) SetStatusMessage(msg string) {
+	hv.statusMessage = msg
+}
+
+// ClearStatusMessage clears the transient status message.
+func (hv *HomeView) ClearStatusMessage() {
+	hv.statusMessage = ""
 }
 
 // UpdateAnimation advances the animation frame for the header.
@@ -843,8 +856,16 @@ func (hv *HomeView) renderFooterWithHeight(height int) string {
 	left := leftStyle.Render(fmt.Sprintf("[ %d skills • %d tags ]",
 		hv.skillCount, hv.tagCount))
 
-	// Center: pull status, scan status, or indexing indicator
+	// Center: status message, pull status, scan status, or indexing indicator
 	center := ""
+
+	// Show transient status message (lowest priority - overridden by active operations)
+	if hv.statusMessage != "" {
+		statusStyle := lipgloss.NewStyle().
+			Foreground(theme.Current.Success).
+			Bold(true)
+		center = statusStyle.Render(hv.statusMessage)
+	}
 
 	// Override with pull progress bar if pulling
 	if hv.pulling {

--- a/internal/tui/views/manage.go
+++ b/internal/tui/views/manage.go
@@ -32,6 +32,7 @@ const (
 	ManageActionBack
 	ManageActionSelectSkill
 	ManageActionSelectDiscovery
+	ManageActionSave
 )
 
 // ManageSkillsLoadedMsg is sent when skills data has been loaded.
@@ -222,6 +223,9 @@ func (mv *ManageView) Update(key string) (ManageAction, tea.Cmd) {
 		default:
 			return ManageActionNone, nil
 		}
+
+	case "S":
+		return ManageActionSave, nil
 	}
 
 	return ManageActionNone, nil
@@ -869,7 +873,7 @@ func (mv *ManageView) renderFooter() string {
 	if mv.section == ManageSectionDiscovered {
 		enterAction = "import"
 	}
-	help := helpStyle.Render(fmt.Sprintf("↑↓ navigate • Tab switch sections • Enter %s • Esc back", enterAction))
+	help := helpStyle.Render(fmt.Sprintf("↑↓ navigate • Tab switch sections • Enter %s • S save • Esc back", enterAction))
 
 	return lipgloss.JoinVertical(lipgloss.Top, count, help)
 }
@@ -901,6 +905,7 @@ func (mv *ManageView) GetKeyboardCommands() ViewCommands {
 			{Key: "d/u", Description: "Page down/up"},
 			{Key: "g/G", Description: "Jump to start/end"},
 			{Key: "Enter", Description: "Edit skill locations"},
+			{Key: "S", Description: "Save project skills to skulto.json"},
 			{Key: "Esc, q", Description: "Return to Home"},
 		},
 	}


### PR DESCRIPTION
- Added `skulto.json` manifest for project-level skill tracking.
- Implemented `skulto save` CLI command to save installed project-scope skills.
- Added synchronous save feature to TUI home and manage views triggered by "S".
- Developed `skulto sync` CLI command to install skills from `skulto.json`.
- CLI `skulto install` supports no-arg usage, delegating to sync behavior.
- Integrated telemetry for manifest save and sync events.
- Utilized atomic write operations for manifest file handling.

## Description

Brief description of changes.

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project style guidelines
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`make test`)
- [ ] The linter passes (`make lint`)
- [ ] I have updated documentation if needed

## Related Issues

Closes #(issue number)
