### PR TITLE
Agents folder refactor

### DIFF
--- a/.claude/skills/adversarial-plan-review
+++ b/.claude/skills/adversarial-plan-review
@@ -1,0 +1,1 @@
+/Users/adamcobb/.agents/skulto/repositories/refactornator/adversarial-plan-review

--- a/.claude/skills/autobuild/SKILL.md
+++ b/.claude/skills/autobuild/SKILL.md
@@ -1,0 +1,661 @@
+---
+name: autobuild
+description: Autonomous single-shot plan execution. Runs entire superplan implementation plans without stopping, using sub-agents for each phase. Phases write state to filesystem for resume capability. Sequential phases run in order, parallel phases (1a, 1b) run concurrently. User never needs to compact context.
+metadata:
+  version: "1.0.0"
+  author: skulto
+compatibility: Requires plan document in superplan format. Sub-agents execute phases independently. State persisted to .autobuild/ directory.
+---
+
+# Autobuild: Autonomous Plan Execution Engine
+
+Execute entire implementation plans in a single pass with zero user intervention. Each phase runs in its own sub-agent, writing state to the filesystem. Context never exhausts because sub-agents are isolated.
+
+## Overview
+
+Autobuild is an **autonomous execution engine** for superplan implementation plans. Unlike `superbuild` which stops after each phase for user confirmation, autobuild runs everything to completion.
+
+**Key Differences from superbuild:**
+
+| Aspect | superbuild | autobuild |
+|--------|------------|-----------|
+| Execution | Phase-by-phase with stops | Continuous until complete |
+| User intervention | Required after each phase | None (fully autonomous) |
+| Context management | Manual compaction | Sub-agents isolate context |
+| State persistence | In conversation | Filesystem (.autobuild/) |
+| Resume capability | Manual | Automatic from state files |
+
+---
+
+## Reference Index - MUST READ When Needed
+
+**References contain detailed templates and patterns. Read BEFORE you need them.**
+
+| When | Reference | What You Get |
+|------|-----------|--------------|
+| **Step 1: Initialize** | [STATE-FILES.md](references/STATE-FILES.md) | State file format, directory structure |
+| **Step 3: Execute phases** | [PHASE-EXECUTION.md](references/PHASE-EXECUTION.md) | Phase ordering, parallel detection, retry logic |
+| **Step 3: Launch sub-agents** | [SUBAGENT-PROMPTS.md](references/SUBAGENT-PROMPTS.md) | Exact prompts for phase sub-agents |
+| **Step 4: Verify and commit** | [VERIFICATION.md](references/VERIFICATION.md) | Fresh verification, commit handling |
+| **Step 5: Handle failures** | [FAILURE-HANDLING.md](references/FAILURE-HANDLING.md) | Retry logic, error recovery |
+| **Overall flow** | [ORCHESTRATION.md](references/ORCHESTRATION.md) | Main orchestration loop, completion handling |
+
+**Also reference superplan documents:**
+- `superplan/references/TASK-MICROSTRUCTURE.md` - TDD 5-step format per task
+- `superplan/references/TDD-DISCIPLINE.md` - TDD enforcement rules
+- `superbuild/references/ENFORCEMENT-GUIDE.md` - Quality gate commands by stack
+
+**DO NOT SKIP REFERENCES.** They contain exact prompts, templates, and formats that are NOT duplicated here.
+
+---
+
+## CLI Arguments
+
+```
+/autobuild <plan-path> [options]
+
+Arguments:
+  plan-path           Path to superplan document (required)
+
+Options:
+  --commit=<mode>     Git commit behavior (required before execution)
+                      - auto: Auto-commit after each phase passes
+                      - message-only: Generate messages, user handles git
+                      - single: One combined commit at the end
+
+  --resume            Resume from existing state (default if .autobuild/ exists)
+  --fresh             Ignore existing state, start from scratch
+  --dry-run           Validate plan and show execution order without running
+```
+
+**Example invocations:**
+```bash
+/autobuild docs/feature-plan.md --commit=auto
+/autobuild docs/feature-plan.md --commit=message-only --resume
+/autobuild docs/feature-plan.md --commit=single --fresh
+```
+
+---
+
+## Critical Workflow
+
+```
++-----------------------------------------------------------------------+
+|                      AUTOBUILD EXECUTION FLOW                          |
++-----------------------------------------------------------------------+
+|                                                                       |
+|  1. INITIALIZE       |  Parse args, create .autobuild/, detect stack  |
+|         |            |  NO PLAN = EXIT (ask user, then exit if none)  |
+|         v            |  NO --commit = STOP (require commit mode)      |
+|  2. LOAD STATE       |  Read existing state files if --resume         |
+|         |            |  Identify completed phases, pending phases     |
+|         v                                                             |
+|  3. EXECUTE PHASES   |  For each pending phase (or parallel group):   |
+|     |                |                                                |
+|     |  3a. Launch sub-agent(s) for phase(s)                           |
+|     |      - Sequential phases: one sub-agent at a time               |
+|     |      - Parallel phases (2a,2b,2c): concurrent sub-agents        |
+|     |                                                                 |
+|     |  3b. Sub-agent executes:                                        |
+|     |      - Read plan section for its phase                          |
+|     |      - Follow TDD micro-structure per task                      |
+|     |      - Run quality gates (lint, test, typecheck)                |
+|     |      - Update plan checkboxes                                   |
+|     |      - Return: status, commit message, files changed            |
+|     |                                                                 |
+|     |  3c. Write state file for phase                                 |
+|         |                                                             |
+|         v                                                             |
+|  4. VERIFY + COMMIT  |  Re-run quality gates fresh (trust but verify) |
+|         |            |  Handle git based on --commit mode              |
+|         v                                                             |
+|  5. ON FAILURE       |  Retry once, then halt with state preserved    |
+|         |            |  Parallel siblings may continue before halt    |
+|         v                                                             |
+|  6. COMPLETION       |  All phases done, output summary               |
+|                      |  State files preserved for audit               |
+|                                                                       |
+|  =====================================================================|
+|  Sub-agents are ISOLATED. Context never exhausts. State is on disk.   |
+|  =====================================================================|
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+---
+
+## Step 1: Initialize
+
+**REQUIRED: Plan document and commit mode must be provided.**
+
+### Argument Validation
+
+```
+AUTOBUILD INITIALIZATION
+=========================
+
+Plan: [path]
+Commit Mode: [auto|message-only|single]
+
+Validating...
+```
+
+**If no plan provided:**
+```
+ERROR: No plan document provided.
+
+Usage: /autobuild <plan-path> --commit=<mode>
+
+Example: /autobuild docs/feature-plan.md --commit=auto
+
+[EXIT - Cannot proceed without plan]
+```
+
+**If no --commit mode specified:**
+```
+COMMIT MODE REQUIRED
+====================
+
+Before I can execute this plan, I need to know how to handle git commits.
+
+Please specify one of:
+  --commit=auto         Auto-commit after each successful phase
+  --commit=message-only Generate messages, you handle git (recommended)
+  --commit=single       One combined commit after all phases complete
+
+Example: /autobuild docs/feature-plan.md --commit=message-only
+
+[WAITING FOR COMMIT MODE]
+```
+
+**NO EXCEPTIONS.** Do not proceed without explicit commit mode.
+
+### Directory Setup
+
+Create `.autobuild/` directory structure:
+
+```
+.autobuild/
+  config.json           # Execution configuration
+  phases/
+    phase-0.json        # State file per phase
+    phase-1.json
+    phase-2a.json
+    phase-2b.json
+    ...
+  logs/
+    execution.log       # Overall execution log
+    phase-0.log         # Per-phase logs (truncated sub-agent output)
+    ...
+```
+
+> **STOP. Read [STATE-FILES.md](references/STATE-FILES.md) NOW** for complete state file format.
+
+### Stack Detection
+
+Detect technology stack to determine quality commands:
+
+```
+STACK DETECTION
+===============
+
+Detected:
+- Language: TypeScript
+- Framework: Express
+- Package Manager: pnpm
+- Test Framework: Jest
+- Linter: ESLint
+- Formatter: Prettier
+
+Quality Commands:
+- Lint: pnpm run lint
+- Format: pnpm run format:check
+- Typecheck: pnpm run typecheck
+- Test: pnpm test
+
+Stack saved to .autobuild/config.json
+```
+
+---
+
+## Step 2: Load State (Resume Support)
+
+If `.autobuild/` exists and `--resume` (or default):
+
+```
+LOADING EXISTING STATE
+======================
+
+Found existing execution state:
+- Config: .autobuild/config.json
+- Phase files: 6 found
+
+Phase Status:
+| Phase | Name | State File | Status |
+|-------|------|------------|--------|
+| 0 | Bootstrap | phase-0.json | complete |
+| 1 | Setup | phase-1.json | complete |
+| 2A | Backend | phase-2a.json | failed |
+| 2B | Frontend | phase-2b.json | complete |
+| 2C | Tests | phase-2c.json | pending |
+| 3 | Integration | phase-3.json | pending |
+
+Resuming from Phase 2A (first incomplete)...
+```
+
+If `--fresh` specified:
+```
+FRESH START
+===========
+
+--fresh flag detected. Clearing existing state.
+
+Removed: .autobuild/ (6 state files)
+Created: .autobuild/ (fresh)
+
+Starting from Phase 0...
+```
+
+---
+
+## Step 3: Execute Phases
+
+### Phase Ordering
+
+> **STOP. Read [PHASE-EXECUTION.md](references/PHASE-EXECUTION.md) NOW** for phase ordering rules.
+
+Parse plan to build execution order:
+
+1. **Identify all phases** from plan overview table
+2. **Build dependency graph** from "Depends On" column
+3. **Identify parallel groups** from "Parallel With" column
+4. **Topologically sort** for execution order
+
+```
+EXECUTION ORDER
+===============
+
+Batch 1 (sequential): Phase 0
+Batch 2 (sequential): Phase 1
+Batch 3 (parallel): Phase 2A, 2B, 2C
+Batch 4 (sequential): Phase 3
+
+Total: 6 phases in 4 batches
+```
+
+### Launching Sub-Agents
+
+> **STOP. Read [SUBAGENT-PROMPTS.md](references/SUBAGENT-PROMPTS.md) NOW** for exact sub-agent prompts.
+
+#### Sequential Phase
+
+```
+EXECUTING PHASE 1: Setup
+========================
+
+Launching sub-agent...
+
+[Sub-agent executes autonomously]
+[Reads plan section]
+[Follows TDD micro-structure]
+[Runs quality gates]
+[Updates plan checkboxes]
+[Returns result]
+
+Sub-agent complete. Processing result...
+```
+
+#### Parallel Phases
+
+```
+EXECUTING PARALLEL BATCH: 2A, 2B, 2C
+=====================================
+
+Launching 3 sub-agents in parallel...
+
+[Sub-agent 2A: Backend API]
+[Sub-agent 2B: Frontend UI]
+[Sub-agent 2C: Edge Case Tests]
+
+Waiting for all sub-agents to complete...
+
+Results received:
+- Phase 2A: complete
+- Phase 2B: complete
+- Phase 2C: complete
+
+Processing parallel results...
+```
+
+**CRITICAL:** Use Task tool with `run_in_background: true` for parallel phases, then collect results with TaskOutput.
+
+### Sub-Agent Execution
+
+Each sub-agent:
+
+1. **Reads the plan** - Specific section for its phase
+2. **Follows TDD** - 5-step micro-structure per task
+3. **Runs quality gates** - Lint, test, typecheck
+4. **Updates plan file** - Checks off completed tasks
+5. **Returns structured result** - JSON with status, commit, files
+
+Sub-agent does NOT:
+- Run git commands (unless --commit=auto in main agent)
+- Modify other phases
+- Access conversation history from main agent
+
+---
+
+## Step 4: Verify and Commit
+
+### Fresh Verification (Trust But Verify)
+
+> **STOP. Read [VERIFICATION.md](references/VERIFICATION.md) NOW** for verification requirements.
+
+**After sub-agent reports success, VERIFY FRESH in main agent:**
+
+```
+VERIFICATION - Phase 2A
+=======================
+
+Sub-agent reported: complete
+
+Running fresh verification...
+
+Lint:      pnpm run lint           ... PASS
+Format:    pnpm run format:check   ... PASS
+Typecheck: pnpm run typecheck      ... PASS
+Tests:     pnpm test               ... PASS (47 tests)
+
+All quality gates passed.
+```
+
+**If verification fails (sub-agent claimed success but check fails):**
+
+```
+VERIFICATION MISMATCH
+=====================
+
+Sub-agent claimed success, but fresh verification failed:
+
+Tests: FAIL
+  5 tests failed in src/services/auth.test.ts
+
+This indicates a sub-agent error. Treating as phase failure.
+Initiating retry...
+```
+
+### Commit Handling
+
+Based on `--commit` mode:
+
+#### --commit=auto
+```
+AUTO-COMMIT - Phase 2A
+======================
+
+git add src/api/auth.ts src/api/auth.test.ts
+git commit -m "$(cat <<'EOF'
+feat(auth): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+
+Commit created: a1b2c3d
+```
+
+#### --commit=message-only
+```
+COMMIT MESSAGE - Phase 2A
+=========================
+
+feat(auth): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+
+Files to commit:
+- src/api/auth.ts (CREATE)
+- src/api/auth.test.ts (CREATE)
+
+[Message saved to .autobuild/phases/phase-2a.json]
+[User handles git operations]
+```
+
+#### --commit=single
+```
+PHASE 2A COMPLETE
+=================
+
+Commit message queued for final combined commit.
+Continuing to next phase...
+```
+
+### State File Update
+
+After each phase (success or failure), update state file:
+
+```
+STATE UPDATED - Phase 2A
+========================
+
+File: .autobuild/phases/phase-2a.json
+Status: complete
+Commit: feat(auth): implement JWT token validation
+Files: 2 created, 0 modified
+Timestamp: 2025-01-25T10:30:00Z
+```
+
+---
+
+## Step 5: Handle Failures
+
+> **STOP. Read [FAILURE-HANDLING.md](references/FAILURE-HANDLING.md) NOW** for failure handling.
+
+### Retry Logic
+
+On phase failure, retry ONCE:
+
+```
+PHASE FAILURE - Phase 2A (Attempt 1/2)
+======================================
+
+Sub-agent reported failure:
+- Tests failed: 3 failing in auth.test.ts
+- Linter: passed
+- Typecheck: passed
+
+Initiating retry...
+
+RETRY - Phase 2A (Attempt 2/2)
+==============================
+
+Launching fresh sub-agent with error context...
+
+[Sub-agent executes with knowledge of previous failure]
+```
+
+### Parallel Sibling Handling
+
+If a parallel phase fails, let siblings complete:
+
+```
+PARALLEL BATCH FAILURE
+======================
+
+Phase 2A: FAILED (after retry)
+Phase 2B: complete
+Phase 2C: running...
+
+Waiting for 2C to complete before halting...
+
+Phase 2C: complete
+
+EXECUTION HALTED
+================
+
+Phase 2A failed after retry.
+Siblings 2B and 2C completed successfully.
+
+State preserved in .autobuild/
+Resume with: /autobuild docs/feature-plan.md --commit=auto --resume
+```
+
+### Halt State
+
+```
+AUTOBUILD HALTED
+================
+
+Execution stopped due to: Phase 2A failure (tests failing)
+
+Completed phases:
+- Phase 0: Bootstrap (complete)
+- Phase 1: Setup (complete)
+- Phase 2B: Frontend (complete)
+- Phase 2C: Tests (complete)
+
+Failed phase:
+- Phase 2A: Backend (failed after retry)
+
+Remaining phases:
+- Phase 3: Integration (blocked by 2A)
+
+State preserved: .autobuild/
+
+To resume after fixing:
+  /autobuild docs/feature-plan.md --commit=auto --resume
+
+To start fresh:
+  /autobuild docs/feature-plan.md --commit=auto --fresh
+```
+
+---
+
+## Step 6: Completion
+
+When all phases complete:
+
+```
++=====================================================================+
+|                     AUTOBUILD COMPLETE                               |
++=====================================================================+
+
+Plan: docs/feature-plan.md
+Duration: [calculated from timestamps]
+Phases: 6/6 complete
+
+Phase Summary:
+| Phase | Name | Status | Commit |
+|-------|------|--------|--------|
+| 0 | Bootstrap | complete | chore(bootstrap): add quality tools |
+| 1 | Setup | complete | feat(db): add user schema |
+| 2A | Backend | complete | feat(api): implement auth endpoints |
+| 2B | Frontend | complete | feat(ui): add login form |
+| 2C | Tests | complete | test(auth): add edge case coverage |
+| 3 | Integration | complete | feat(auth): wire frontend to backend |
+
+Files Changed: [total count]
+Tests Added: [count from test output]
+Coverage: [if available]
+
+State preserved: .autobuild/
+
+[Based on --commit mode, output final instructions]
+```
+
+### --commit=auto completion
+```
+All commits created successfully.
+Review with: git log --oneline -6
+```
+
+### --commit=message-only completion
+```
+PENDING COMMITS
+===============
+
+The following commits are ready to create:
+
+1. chore(bootstrap): add quality tools
+   git add ... && git commit -m "..."
+
+2. feat(db): add user schema
+   git add ... && git commit -m "..."
+
+[etc.]
+
+Full commit commands saved to: .autobuild/commits.sh
+Run with: bash .autobuild/commits.sh
+```
+
+### --commit=single completion
+```
+COMBINED COMMIT MESSAGE
+=======================
+
+feat(auth): implement complete authentication system
+
+This commit includes:
+- Bootstrap: quality tools configuration
+- Database: user schema and migrations
+- API: authentication endpoints with JWT
+- UI: login and registration forms
+- Tests: comprehensive test coverage
+- Integration: full e2e authentication flow
+
+Phases completed: 6
+Files changed: [count]
+```
+
+---
+
+## Rationalizations to Reject
+
+| Excuse | Reality |
+|--------|---------|
+| "Let me run multiple phases in one sub-agent" | **NO.** Each phase gets its own sub-agent for context isolation |
+| "I'll skip the state file for this phase" | **NO.** State files enable resume and audit |
+| "The sub-agent passed, no need to verify" | **NO.** Fresh verification is mandatory |
+| "Let me just continue after failure" | **NO.** Retry once, then halt |
+| "Sequential phases can run in parallel" | **NO.** Respect dependency order |
+| "I'll batch the verification at the end" | **NO.** Verify after each phase |
+| "The plan doesn't specify commit mode" | **NO.** Require --commit before execution |
+| "Let me auto-commit without being told" | **NO.** Explicit commit mode required |
+
+---
+
+## Red Flags - STOP Immediately
+
+If you catch yourself thinking any of these, STOP:
+
+- "Context is getting long, let me combine phases"
+- "This phase is simple, I can skip the sub-agent"
+- "The retry failed, but let me try once more"
+- "Sequential phases don't really depend on each other"
+- "I'll write the state files at the end"
+- "Verification is redundant, sub-agents are reliable"
+- "The user probably wants auto-commit"
+
+**All of these = violation of autobuild protocol.**
+
+---
+
+## The Iron Rules
+
+1. **Explicit commit mode** - Never start without --commit flag
+2. **One sub-agent per phase** - Context isolation is non-negotiable
+3. **State file per phase** - Written immediately after completion/failure
+4. **Fresh verification** - Never trust sub-agent claims alone
+5. **Single retry on failure** - Then halt with state preserved
+6. **Respect dependencies** - Sequential means sequential
+7. **Parallel means parallel** - Launch concurrent sub-agents
+8. **Resume from state** - Check .autobuild/ before starting
+9. **Preserve state on halt** - Enable future resume
+10. **No user intervention** - Fully autonomous execution
+
+**Autobuild is rigid by design.** The sub-agent isolation prevents context exhaustion. The state files enable resume. The verification ensures quality. Do not rationalize around it.

--- a/.claude/skills/autobuild/references/FAILURE-HANDLING.md
+++ b/.claude/skills/autobuild/references/FAILURE-HANDLING.md
@@ -1,0 +1,569 @@
+# Failure Handling Reference
+
+> Retry logic, error recovery, parallel sibling handling, and halt procedures.
+
+## Failure Classification
+
+| Failure Type | Retryable | Description |
+|--------------|-----------|-------------|
+| `test_failure` | Yes | Tests failed, code may need fixes |
+| `lint_error` | Yes | Linting errors, auto-fixable or manual |
+| `typecheck_error` | Yes | Type errors in implementation |
+| `format_error` | Yes | Usually auto-fixable |
+| `task_incomplete` | Yes | Sub-agent didn't finish all tasks |
+| `verification_mismatch` | Yes | Claimed success but verification failed |
+| `timeout` | Yes | Sub-agent took too long |
+| `parse_error` | Yes | Couldn't parse sub-agent result |
+| `dependency_missing` | No | Required package/tool not installed |
+| `circular_dependency` | No | Plan has circular phase dependencies |
+| `file_conflict` | No | Parallel phases modified same file |
+| `plan_invalid` | No | Plan format is incorrect |
+
+---
+
+## Retry Logic
+
+### Single Retry Strategy
+
+Each phase gets exactly ONE retry before failure:
+
+```
+PHASE FAILURE HANDLING
+======================
+
+Attempt 1: Execute phase normally
+            |
+            v
+        Failed?
+       /       \
+      No        Yes
+      |          |
+   Success    Attempt 2: Execute with error context
+                   |
+                   v
+               Failed?
+              /       \
+             No        Yes
+             |          |
+          Success    HALT
+```
+
+### Why Single Retry?
+
+1. **Efficiency** - Multiple retries waste time on unfixable issues
+2. **Signal** - Two failures strongly suggest manual intervention needed
+3. **Determinism** - Predictable behavior, not indefinite loops
+4. **Context** - Retry includes error context for better chance of success
+
+---
+
+## Retry Execution
+
+### Initiating Retry
+
+```
+PHASE FAILURE - Initiating Retry
+================================
+
+Phase: 2A (Backend API)
+Attempt: 1 of 2
+
+Failure details:
+  Type: test_failure
+  Message: 3 tests failing in auth.test.ts
+  Tests: validateToken, refreshToken, handleExpired
+
+Launching retry sub-agent with error context...
+
+[See SUBAGENT-PROMPTS.md for retry prompt template]
+```
+
+### Error Context for Retry
+
+Pass previous failure information to retry sub-agent:
+
+```python
+def build_retry_context(phase_state):
+    return {
+        "previous_error_type": phase_state["error"]["type"],
+        "previous_error_message": phase_state["error"]["message"],
+        "previous_error_details": phase_state["error"].get("details", ""),
+        "tasks_completed": phase_state["execution"]["tasks_completed"],
+        "tasks_total": phase_state["execution"]["tasks_total"],
+        "retry_guidance": get_retry_guidance(phase_state["error"]["type"])
+    }
+```
+
+### Retry State Update
+
+Before retry:
+```json
+{
+  "phase_id": "2a",
+  "status": "running",
+  "attempt": 2,
+  "max_attempts": 2,
+  "error": {
+    "attempt_1": {
+      "type": "test_failure",
+      "message": "3 tests failing"
+    }
+  }
+}
+```
+
+After retry success:
+```json
+{
+  "phase_id": "2a",
+  "status": "complete",
+  "attempt": 2,
+  "error": {
+    "attempt_1": {
+      "type": "test_failure",
+      "message": "3 tests failing"
+    },
+    "resolved_on_retry": true
+  }
+}
+```
+
+After retry failure:
+```json
+{
+  "phase_id": "2a",
+  "status": "failed",
+  "attempt": 2,
+  "error": {
+    "attempt_1": {
+      "type": "test_failure",
+      "message": "3 tests failing"
+    },
+    "attempt_2": {
+      "type": "test_failure",
+      "message": "3 tests still failing"
+    },
+    "final": "Failed after maximum retries"
+  }
+}
+```
+
+---
+
+## Parallel Sibling Handling
+
+When a phase in a parallel batch fails:
+
+### Let Siblings Complete
+
+```
+PARALLEL BATCH - PARTIAL FAILURE
+================================
+
+Batch: [2A, 2B, 2C]
+
+Status:
+  Phase 2A: FAILED (attempt 1)
+  Phase 2B: running...
+  Phase 2C: complete
+
+Decision: Allow running siblings to complete before retry.
+
+Rationale:
+1. Siblings may succeed, preserving their work
+2. Retry of 2A won't conflict with running 2B
+3. More efficient than cancelling all
+
+Waiting for 2B to complete...
+```
+
+### Sibling Completion Then Retry
+
+```
+PARALLEL BATCH - RETRY AFTER SIBLINGS
+=====================================
+
+All siblings complete:
+  Phase 2A: failed (attempt 1)
+  Phase 2B: complete
+  Phase 2C: complete
+
+Initiating retry for Phase 2A...
+
+Note: 2B and 2C results preserved. Their commits (if --commit=auto)
+already created. 2A retry runs in isolation.
+```
+
+### Multiple Siblings Fail
+
+```
+PARALLEL BATCH - MULTIPLE FAILURES
+==================================
+
+Batch: [2A, 2B, 2C]
+
+Results:
+  Phase 2A: failed
+  Phase 2B: failed
+  Phase 2C: complete
+
+Multiple phases failed. Retrying each:
+
+Retry 1: Phase 2A (parallel with 2B retry)
+Retry 2: Phase 2B (parallel with 2A retry)
+
+[Retries run in parallel since they're independent]
+
+Retry results:
+  Phase 2A: complete (retry succeeded)
+  Phase 2B: failed (retry failed)
+
+Phase 2B failed after retry.
+AUTOBUILD HALTED
+```
+
+---
+
+## Halt Procedure
+
+When halt is triggered:
+
+### Halt Sequence
+
+```
+AUTOBUILD HALT SEQUENCE
+=======================
+
+1. Stop launching new phases
+2. Wait for running phases to complete (or timeout)
+3. Write final state files
+4. Update execution log
+5. Output halt summary
+6. Preserve state for resume
+```
+
+### Halt Summary Output
+
+```
+╔═══════════════════════════════════════════════════════════════════╗
+║                       AUTOBUILD HALTED                             ║
+╠═══════════════════════════════════════════════════════════════════╣
+║                                                                   ║
+║  Reason: Phase 2A failed after retry                              ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  COMPLETED PHASES                                                 ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Phase 0: Bootstrap .......................... complete           ║
+║    Commit: chore(bootstrap): add quality tools                    ║
+║                                                                   ║
+║  Phase 1: Setup .............................. complete           ║
+║    Commit: feat(db): add user schema                              ║
+║                                                                   ║
+║  Phase 2B: Frontend .......................... complete           ║
+║    Commit: feat(ui): add login form                               ║
+║                                                                   ║
+║  Phase 2C: Tests ............................. complete           ║
+║    Commit: test(auth): add edge cases                             ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  FAILED PHASE                                                     ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Phase 2A: Backend ........................... FAILED             ║
+║    Attempts: 2/2                                                  ║
+║    Error: test_failure                                            ║
+║    Details: 3 tests failing - validateToken returns null          ║
+║             instead of user object                                ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  BLOCKED PHASES                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Phase 3: Integration ........................ blocked            ║
+║    Blocked by: 2A                                                 ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  STATE PRESERVED                                                  ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Directory: .autobuild/                                           ║
+║  State files: 6 phases                                            ║
+║  Logs: .autobuild/logs/                                           ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  RESUME INSTRUCTIONS                                              ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  1. Fix the failing tests in src/api/auth.test.ts                 ║
+║  2. Run: /autobuild docs/feature-plan.md --commit=auto --resume   ║
+║                                                                   ║
+║  To start fresh: Add --fresh flag                                 ║
+║                                                                   ║
+╚═══════════════════════════════════════════════════════════════════╝
+```
+
+---
+
+## Error Type Handling
+
+### test_failure
+
+```
+ERROR: test_failure
+==================
+
+Symptoms:
+- Test command exited with non-zero
+- One or more test cases failed
+
+Information to capture:
+- Number of tests failed
+- Test file paths
+- Test names
+- Error messages
+
+Retry guidance:
+"Fix the failing tests. The errors are in {FILES}.
+Common issues: incorrect assertions, missing mocks, async timing."
+
+User action if retry fails:
+- Review test failures manually
+- Check if tests are flaky
+- Verify test assumptions match implementation
+```
+
+### lint_error
+
+```
+ERROR: lint_error
+=================
+
+Symptoms:
+- Linter exited with non-zero
+- Linting rules violated
+
+Information to capture:
+- Number of errors
+- File paths with errors
+- Rule names violated
+- Line numbers
+
+Retry guidance:
+"Fix linting errors. Run `{LINT_COMMAND}` to see current errors.
+Most are auto-fixable with `{LINT_FIX_COMMAND}`."
+
+User action if retry fails:
+- Review lint rules
+- Consider disabling problematic rules
+- Check for conflicting lint configurations
+```
+
+### typecheck_error
+
+```
+ERROR: typecheck_error
+======================
+
+Symptoms:
+- Type checker exited with non-zero
+- Type mismatches or missing types
+
+Information to capture:
+- Number of errors
+- File paths with errors
+- Error messages (type expected vs actual)
+- Line numbers
+
+Retry guidance:
+"Fix type errors. Run `{TYPECHECK_COMMAND}` to see current errors.
+Check that function signatures match usage."
+
+User action if retry fails:
+- Review type definitions
+- Check for missing @types packages
+- Verify tsconfig/mypy configuration
+```
+
+### timeout
+
+```
+ERROR: timeout
+==============
+
+Symptoms:
+- Sub-agent didn't respond within time limit
+- May have been stuck on a task
+
+Information to capture:
+- How long before timeout
+- Last known activity (if any)
+
+Retry guidance:
+"Previous attempt timed out. Focus on completing tasks efficiently.
+If tests are slow, consider running targeted tests only."
+
+User action if retry fails:
+- Increase timeout (if justified)
+- Break phase into smaller phases
+- Check for infinite loops or hanging operations
+```
+
+### verification_mismatch
+
+```
+ERROR: verification_mismatch
+============================
+
+Symptoms:
+- Sub-agent claimed success
+- Fresh verification in main agent failed
+
+Information to capture:
+- What sub-agent claimed
+- What fresh verification found
+- Discrepancy details
+
+Retry guidance:
+"Previous sub-agent reported success but verification failed.
+Run ALL quality gates after EVERY change. Ensure tests pass
+at the end, not just during development."
+
+User action if retry fails:
+- Review sub-agent logs
+- Check for race conditions
+- Verify no external state changes
+```
+
+---
+
+## Non-Retryable Errors
+
+### dependency_missing
+
+```
+ERROR: dependency_missing (NON-RETRYABLE)
+=========================================
+
+Required dependency not installed:
+  Package: @types/jest
+  Required by: Type checking
+
+AUTOBUILD CANNOT PROCEED
+
+Resolution:
+  Install missing dependency: npm install -D @types/jest
+  Then resume: /autobuild docs/feature-plan.md --commit=auto --resume
+
+[HALTED - Manual intervention required]
+```
+
+### circular_dependency
+
+```
+ERROR: circular_dependency (NON-RETRYABLE)
+==========================================
+
+Plan contains circular phase dependencies:
+  Phase 2A depends on Phase 3
+  Phase 3 depends on Phase 2A
+
+AUTOBUILD CANNOT PROCEED
+
+Resolution:
+  Fix the plan's "Depends On" column to remove the cycle.
+  Ensure dependencies form a directed acyclic graph (DAG).
+
+[HALTED - Invalid plan]
+```
+
+### file_conflict
+
+```
+ERROR: file_conflict (NON-RETRYABLE)
+====================================
+
+Parallel phases modified the same file:
+  File: src/api/routes.ts
+  Phase 2A modified lines 10-25
+  Phase 2B modified lines 15-30
+
+AUTOBUILD CANNOT PROCEED
+
+Resolution options:
+1. Manually merge the changes
+2. Modify plan to make these phases sequential
+3. Split the shared file to avoid conflicts
+
+[HALTED - Parallel conflict]
+```
+
+---
+
+## Recovery Scenarios
+
+### Resume After Fix
+
+User fixes the issue externally, then resumes:
+
+```
+RESUME AFTER EXTERNAL FIX
+=========================
+
+Previous state:
+  Phase 2A: failed (test_failure)
+
+User action: Fixed tests in src/api/auth.test.ts
+
+Resume command: /autobuild docs/feature-plan.md --commit=auto --resume
+
+Resume behavior:
+1. Read state files
+2. Find Phase 2A in failed status
+3. Reset attempt count to 0
+4. Re-execute Phase 2A
+5. Continue with remaining phases if successful
+```
+
+### Fresh Start After Corruption
+
+If state files are corrupted or need reset:
+
+```
+FRESH START
+===========
+
+User command: /autobuild docs/feature-plan.md --commit=auto --fresh
+
+Behavior:
+1. Delete .autobuild/ directory
+2. Create fresh state files
+3. Start from Phase 0
+4. All previous commits remain (if --commit=auto was used)
+
+Warning: Does not undo previous commits. Use git reset if needed.
+```
+
+### Partial Recovery
+
+User wants to keep some completed work:
+
+```
+PARTIAL RECOVERY
+================
+
+Scenario: Phases 0-2B complete, 2C and later need re-run
+
+Option 1: Edit state files manually
+  - Set phase-2c.json status to "pending"
+  - Delete phase-3.json (or set to "pending")
+  - Run with --resume
+
+Option 2: Use fresh and re-commit
+  - Run with --fresh
+  - All phases re-execute
+  - Creates duplicate commits (may need squash)
+
+Recommendation: Option 1 for surgical recovery
+```

--- a/.claude/skills/autobuild/references/ORCHESTRATION.md
+++ b/.claude/skills/autobuild/references/ORCHESTRATION.md
@@ -1,0 +1,592 @@
+# Orchestration Reference
+
+> Main execution loop, phase coordination, and completion handling.
+
+## Orchestration Overview
+
+The main agent orchestrates execution without accumulating context:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    ORCHESTRATION RESPONSIBILITIES                    │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  Main Agent (Orchestrator):                                         │
+│  ├── Parse arguments and validate                                   │
+│  ├── Initialize .autobuild/ directory                               │
+│  ├── Detect technology stack                                        │
+│  ├── Parse plan and build execution order                           │
+│  ├── Load existing state (if --resume)                              │
+│  ├── Launch sub-agents for each phase                               │
+│  ├── Verify sub-agent results                                       │
+│  ├── Handle commits based on --commit mode                          │
+│  ├── Handle failures and retries                                    │
+│  └── Output completion or halt summary                              │
+│                                                                     │
+│  Sub-Agents (Executors):                                            │
+│  ├── Read their phase section from plan                             │
+│  ├── Execute tasks following TDD                                    │
+│  ├── Run quality gates                                              │
+│  ├── Update plan file                                               │
+│  └── Return structured result JSON                                  │
+│                                                                     │
+│  Filesystem (State):                                                │
+│  ├── .autobuild/config.json - execution config                      │
+│  ├── .autobuild/phases/*.json - phase state files                   │
+│  └── .autobuild/logs/*.log - execution logs                         │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Main Execution Loop
+
+### Pseudocode
+
+```python
+def autobuild_main(plan_path, commit_mode, resume, fresh):
+    # Step 1: Initialize
+    validate_arguments(plan_path, commit_mode)
+    if fresh:
+        delete_autobuild_dir()
+    create_autobuild_dir()
+    config = detect_stack_and_commands()
+    save_config(config)
+
+    # Step 2: Parse plan
+    plan = read_plan(plan_path)
+    phases = parse_phases(plan)
+    batches = create_execution_batches(phases)
+
+    # Step 3: Load state (if resume)
+    if resume and state_exists():
+        states = load_phase_states()
+        resume_point = find_resume_point(states, batches)
+    else:
+        states = create_initial_states(phases)
+        resume_point = batches[0]
+
+    # Step 4: Execute batches
+    for batch in batches:
+        if batch_before(batch, resume_point):
+            continue  # Already complete
+
+        if batch["type"] == "sequential":
+            result = execute_sequential_batch(batch, config, states)
+        else:
+            result = execute_parallel_batch(batch, config, states)
+
+        if result["status"] == "failed":
+            output_halt_summary(states, result["failed_phase"])
+            return
+
+    # Step 5: Completion
+    output_completion_summary(states, commit_mode)
+```
+
+### Batch Execution Functions
+
+```python
+def execute_sequential_batch(batch, config, states):
+    for phase_id in batch["phases"]:
+        result = execute_phase(phase_id, config, states)
+
+        if result["status"] == "failed":
+            # Try retry
+            retry_result = retry_phase(phase_id, config, states, result["error"])
+
+            if retry_result["status"] == "failed":
+                return {"status": "failed", "failed_phase": phase_id}
+
+    return {"status": "complete"}
+
+
+def execute_parallel_batch(batch, config, states):
+    # Launch all phases in parallel
+    tasks = {}
+    for phase_id in batch["phases"]:
+        task_id = launch_phase_background(phase_id, config)
+        tasks[phase_id] = task_id
+
+    # Wait for all to complete
+    results = {}
+    for phase_id, task_id in tasks.items():
+        results[phase_id] = wait_for_task(task_id)
+
+    # Check for failures
+    failed = [p for p, r in results.items() if r["status"] == "failed"]
+
+    if failed:
+        # Retry failed phases (can also be parallel)
+        retry_results = retry_phases_parallel(failed, config, states, results)
+
+        still_failed = [p for p, r in retry_results.items() if r["status"] == "failed"]
+
+        if still_failed:
+            return {"status": "failed", "failed_phase": still_failed[0]}
+
+    return {"status": "complete"}
+```
+
+---
+
+## Phase Execution Flow
+
+### Single Phase Execution
+
+```
+PHASE EXECUTION: {PHASE_ID}
+===========================
+
+1. CREATE/UPDATE state file
+   Status: running
+   Attempt: {N}
+
+2. LAUNCH sub-agent
+   [See SUBAGENT-PROMPTS.md]
+
+3. WAIT for sub-agent completion
+   Timeout: 10 minutes
+
+4. PARSE sub-agent result
+   Extract JSON from output
+
+5. VERIFY results
+   Run fresh quality gates
+   Check files exist
+   Check plan updated
+
+6. IF verification passes:
+   - Update state: complete
+   - Handle commit
+   - Log success
+
+7. IF verification fails:
+   - Update state: error details
+   - Return failure for retry handling
+```
+
+### State File Updates During Execution
+
+```python
+def execute_phase(phase_id, config, states):
+    # Mark as running
+    update_state(phase_id, {
+        "status": "running",
+        "attempt": states[phase_id]["attempt"] + 1,
+        "timestamps": {"started": now()}
+    })
+
+    # Launch sub-agent
+    result = launch_subagent(phase_id, config)
+
+    # Verify
+    verification = verify_result(result, config)
+
+    if verification["passed"]:
+        update_state(phase_id, {
+            "status": "complete",
+            "timestamps": {"completed": now()},
+            "quality_gates": verification["gates"],
+            "commit": result["commit_message"],
+            "files": result["files"]
+        })
+        return {"status": "complete", "result": result}
+    else:
+        update_state(phase_id, {
+            "error": {
+                f"attempt_{states[phase_id]['attempt'] + 1}": {
+                    "type": verification["error_type"],
+                    "message": verification["error_message"]
+                }
+            }
+        })
+        return {"status": "failed", "error": verification}
+```
+
+---
+
+## Parallel Execution Coordination
+
+### Launching Parallel Sub-Agents
+
+```
+PARALLEL LAUNCH: [2A, 2B, 2C]
+=============================
+
+1. For each phase in batch:
+   - Create state file (status: running)
+   - Launch Task with run_in_background: true
+   - Store task ID
+
+2. All tasks launched
+   Task 2A: task-abc-123
+   Task 2B: task-def-456
+   Task 2C: task-ghi-789
+
+3. Wait for completion
+   Using TaskOutput with block: true
+   Timeout: 15 minutes per task
+
+4. Collect results as they complete
+   2C complete: 5m 45s
+   2B complete: 8m 30s
+   2A complete: 10m 15s
+```
+
+### Parallel Task Tool Calls
+
+Launch all parallel phases in a SINGLE message with multiple Task tool calls:
+
+```
+[Message with 3 Task tool calls]
+
+Task 1:
+  description: "Execute Phase 2A"
+  prompt: [2A prompt]
+  subagent_type: "general-purpose"
+  run_in_background: true
+
+Task 2:
+  description: "Execute Phase 2B"
+  prompt: [2B prompt]
+  subagent_type: "general-purpose"
+  run_in_background: true
+
+Task 3:
+  description: "Execute Phase 2C"
+  prompt: [2C prompt]
+  subagent_type: "general-purpose"
+  run_in_background: true
+```
+
+### Collecting Parallel Results
+
+```python
+def collect_parallel_results(task_ids, timeout_per_task=600000):
+    results = {}
+
+    for phase_id, task_id in task_ids.items():
+        output = TaskOutput(
+            task_id=task_id,
+            block=True,
+            timeout=timeout_per_task
+        )
+        results[phase_id] = parse_subagent_result(output)
+
+    return results
+```
+
+---
+
+## Commit Orchestration
+
+### --commit=auto Flow
+
+```
+COMMIT ORCHESTRATION (auto)
+===========================
+
+After each phase verification passes:
+
+1. Stage files
+   git add {files_created} {files_modified}
+
+2. Create commit
+   git commit -m "{commit_message}"
+
+3. Capture commit SHA
+   sha = git rev-parse HEAD
+
+4. Update state file
+   commit.committed = true
+   commit.commit_sha = sha
+
+5. Continue to next phase
+```
+
+### --commit=message-only Flow
+
+```
+COMMIT ORCHESTRATION (message-only)
+===================================
+
+After each phase verification passes:
+
+1. Save commit message to state file
+   .autobuild/phases/phase-{id}.json
+
+2. Append to commits script
+   .autobuild/commits.sh
+
+3. Do NOT run git commands
+
+4. Continue to next phase
+
+At completion:
+  Output list of pending commits
+  Point user to commits.sh
+```
+
+### --commit=single Flow
+
+```
+COMMIT ORCHESTRATION (single)
+=============================
+
+After each phase verification passes:
+
+1. Save commit message to state file
+   Mark as "queued for combined commit"
+
+2. Do NOT run git commands
+
+3. Continue to next phase
+
+At completion:
+  Combine all commit messages
+  Create single combined commit message
+  Optionally stage and commit all files
+```
+
+---
+
+## Completion Handling
+
+### All Phases Successful
+
+```python
+def output_completion_summary(states, commit_mode):
+    completed = [s for s in states.values() if s["status"] == "complete"]
+    total_files = sum(len(s["files"]["created"]) + len(s["files"]["modified"])
+                      for s in completed)
+
+    print("""
+╔═══════════════════════════════════════════════════════════════════╗
+║                     AUTOBUILD COMPLETE                             ║
+╠═══════════════════════════════════════════════════════════════════╣
+""")
+
+    # Phase summary table
+    for state in completed:
+        print(f"║  Phase {state['phase_id']}: {state['phase_name']} ... complete")
+        print(f"║    Commit: {state['commit']['message'].split(chr(10))[0]}")
+
+    print(f"""
+║  ─────────────────────────────────────────────────────────────
+║  Total phases: {len(completed)}
+║  Total files changed: {total_files}
+║  State preserved: .autobuild/
+╚═══════════════════════════════════════════════════════════════════╝
+""")
+
+    # Commit mode specific instructions
+    if commit_mode == "auto":
+        print("All commits created. Review with: git log --oneline")
+    elif commit_mode == "message-only":
+        print("Commits ready. Run: bash .autobuild/commits.sh")
+    elif commit_mode == "single":
+        output_combined_commit(states)
+```
+
+### Creating commits.sh
+
+```python
+def create_commits_script(states):
+    script = """#!/bin/bash
+# Generated by autobuild
+# Run with: bash .autobuild/commits.sh
+
+set -e
+
+"""
+    for state in sorted(states.values(), key=lambda s: s["timestamps"]["completed"]):
+        if state["status"] != "complete":
+            continue
+
+        files = state["files"]["created"] + state["files"]["modified"]
+        files_str = " ".join(f'"{f}"' for f in files)
+        message = state["commit"]["message"]
+
+        script += f'''
+echo "Committing Phase {state['phase_id']}: {state['phase_name']}..."
+git add {files_str}
+git commit -m "$(cat <<'EOF'
+{message}
+EOF
+)"
+
+'''
+
+    script += 'echo "All commits complete!"\n'
+
+    write_file(".autobuild/commits.sh", script)
+    Bash(command="chmod +x .autobuild/commits.sh")
+```
+
+---
+
+## Logging
+
+### Execution Log Entries
+
+```python
+def log_event(event_type, message, details=None):
+    timestamp = datetime.now().isoformat()
+    entry = f"[{timestamp}] {event_type}: {message}"
+    if details:
+        entry += f"\n  Details: {details}"
+
+    append_file(".autobuild/logs/execution.log", entry + "\n")
+```
+
+### Log Event Types
+
+| Event | Example |
+|-------|---------|
+| `START` | `AUTOBUILD STARTED - plan: docs/feature-plan.md` |
+| `CONFIG` | `Stack detected: typescript/express` |
+| `BATCH` | `Executing batch 3 (parallel): [2A, 2B, 2C]` |
+| `PHASE_START` | `Phase 2A started (attempt 1)` |
+| `PHASE_COMPLETE` | `Phase 2A complete - feat(api): add auth endpoints` |
+| `PHASE_FAIL` | `Phase 2A failed - test_failure: 3 tests failing` |
+| `RETRY` | `Phase 2A retry initiated (attempt 2)` |
+| `VERIFY` | `Verification passed for Phase 2A` |
+| `COMMIT` | `Commit created: a1b2c3d` |
+| `HALT` | `AUTOBUILD HALTED - Phase 2A failed after retry` |
+| `COMPLETE` | `AUTOBUILD COMPLETE - 6 phases, 24 files` |
+
+### Phase Log Files
+
+Each phase gets a truncated log of its sub-agent execution:
+
+```python
+def save_phase_log(phase_id, subagent_output):
+    # Truncate to reasonable size
+    max_lines = 500
+    lines = subagent_output.split("\n")
+    if len(lines) > max_lines:
+        truncated = lines[:max_lines//2] + ["...[truncated]..."] + lines[-max_lines//2:]
+        output = "\n".join(truncated)
+    else:
+        output = subagent_output
+
+    log_content = f"""=== PHASE {phase_id} SUB-AGENT LOG ===
+Started: {now()}
+
+{output}
+
+=== END PHASE {phase_id} LOG ===
+"""
+
+    write_file(f".autobuild/logs/phase-{phase_id}.log", log_content)
+```
+
+---
+
+## Error Recovery
+
+### Graceful Shutdown
+
+If interrupted (Ctrl+C or system shutdown):
+
+```
+GRACEFUL SHUTDOWN
+=================
+
+Interrupt detected.
+
+Actions:
+1. Signal running sub-agents to stop (if possible)
+2. Update state files with current status
+3. Mark interrupted phases as "running" (will resume)
+4. Save execution log
+
+State preserved. Resume with --resume flag.
+```
+
+### State Corruption Detection
+
+```python
+def validate_state_consistency():
+    config = load_config()
+    states = load_all_states()
+
+    issues = []
+
+    # Check all expected phases have state files
+    for phase_id in config["phases"]:
+        if phase_id not in states:
+            issues.append(f"Missing state file for phase {phase_id}")
+
+    # Check no phase claims complete without commit
+    for state in states.values():
+        if state["status"] == "complete" and not state["commit"]:
+            issues.append(f"Phase {state['phase_id']} complete but no commit")
+
+    # Check dependency consistency
+    for state in states.values():
+        if state["status"] == "complete":
+            for dep in state["dependencies"]["depends_on"]:
+                if states[dep]["status"] != "complete":
+                    issues.append(f"Phase {state['phase_id']} complete but dependency {dep} not complete")
+
+    return issues
+```
+
+### Recovery from Corruption
+
+```
+STATE VALIDATION FAILED
+=======================
+
+Issues detected:
+1. Phase 2a complete but dependency 1 not complete
+2. Missing state file for phase 2c
+
+Options:
+1. Attempt automatic repair
+2. Start fresh with --fresh
+3. Manual state file editing
+
+Recommendation: Start fresh to ensure consistency.
+
+Command: /autobuild docs/feature-plan.md --commit=auto --fresh
+```
+
+---
+
+## Progress Tracking
+
+### Progress Output During Execution
+
+```
+AUTOBUILD PROGRESS
+==================
+
+Plan: docs/feature-plan.md
+Mode: --commit=auto
+
+[■■■■■■■■■■░░░░░░░░░░] 50% (3/6 phases)
+
+Completed:
+  ✓ Phase 0: Bootstrap (2m 15s)
+  ✓ Phase 1: Setup (3m 45s)
+  ✓ Phase 2C: Tests (5m 30s)
+
+In Progress:
+  ⟳ Phase 2A: Backend (running for 4m 20s)
+  ⟳ Phase 2B: Frontend (running for 4m 20s)
+
+Pending:
+  ○ Phase 3: Integration
+
+Estimated remaining: ~15 minutes
+```
+
+### Progress Update Frequency
+
+- Update after each phase completes
+- Update every 60 seconds during long phases
+- Immediate update on failure or halt

--- a/.claude/skills/autobuild/references/PHASE-EXECUTION.md
+++ b/.claude/skills/autobuild/references/PHASE-EXECUTION.md
@@ -1,0 +1,527 @@
+# Phase Execution Reference
+
+> Phase ordering, parallel detection, dependency resolution, and execution batching.
+
+## Phase Identification
+
+### Parsing Phase Overview Table
+
+Plans contain a phase overview table:
+
+```markdown
+| Phase | Name | Depends On | Parallel With | Estimate | Status |
+|-------|------|------------|---------------|----------|--------|
+| 0 | Bootstrap | - | - | 5 | ⬜ |
+| 1 | Setup | 0 | - | 3 | ⬜ |
+| 2A | Backend | 1 | 2B, 2C | 8 | ⬜ |
+| 2B | Frontend | 1 | 2A, 2C | 5 | ⬜ |
+| 2C | Tests | 1 | 2A, 2B | 3 | ⬜ |
+| 3 | Integration | 2A, 2B, 2C | - | 5 | ⬜ |
+```
+
+### Phase ID Normalization
+
+| Raw ID | Normalized |
+|--------|------------|
+| `Phase 0` | `0` |
+| `Phase 1` | `1` |
+| `Phase 2A` | `2a` |
+| `Phase 2-A` | `2a` |
+| `2A` | `2a` |
+| `Phase 2a` | `2a` |
+
+**Rules:**
+1. Remove "Phase" prefix
+2. Lowercase all letters
+3. Remove spaces and hyphens
+4. Keep alphanumeric only
+
+### Detecting Parallel Groups
+
+Phases are parallel if they share "Parallel With" entries:
+
+```
+Phase 2A: Parallel With [2B, 2C]
+Phase 2B: Parallel With [2A, 2C]
+Phase 2C: Parallel With [2A, 2B]
+
+-> Parallel Group: [2A, 2B, 2C]
+```
+
+**Algorithm:**
+```python
+def find_parallel_groups(phases):
+    groups = []
+    seen = set()
+
+    for phase in phases:
+        if phase.id in seen:
+            continue
+
+        if phase.parallel_with:
+            group = {phase.id} | set(phase.parallel_with)
+            groups.append(sorted(group))
+            seen.update(group)
+        else:
+            groups.append([phase.id])
+            seen.add(phase.id)
+
+    return groups
+```
+
+---
+
+## Dependency Resolution
+
+### Building Dependency Graph
+
+```python
+def build_dependency_graph(phases):
+    graph = {}
+    for phase in phases:
+        graph[phase.id] = {
+            "depends_on": phase.depends_on or [],
+            "parallel_with": phase.parallel_with or [],
+            "blocks": []  # Computed below
+        }
+
+    # Compute reverse dependencies (blocks)
+    for phase_id, deps in graph.items():
+        for dep in deps["depends_on"]:
+            graph[dep]["blocks"].append(phase_id)
+
+    return graph
+```
+
+### Example Graph
+
+```
+Phase 0: depends_on=[], blocks=[1]
+Phase 1: depends_on=[0], blocks=[2a, 2b, 2c]
+Phase 2A: depends_on=[1], parallel_with=[2b, 2c], blocks=[3]
+Phase 2B: depends_on=[1], parallel_with=[2a, 2c], blocks=[3]
+Phase 2C: depends_on=[1], parallel_with=[2a, 2b], blocks=[3]
+Phase 3: depends_on=[2a, 2b, 2c], blocks=[]
+```
+
+### Topological Sort
+
+Sort phases respecting dependencies:
+
+```python
+def topological_sort(graph):
+    result = []
+    in_degree = {node: len(deps["depends_on"]) for node, deps in graph.items()}
+    queue = [node for node, degree in in_degree.items() if degree == 0]
+
+    while queue:
+        # Sort queue to process parallel groups together
+        queue.sort()
+        node = queue.pop(0)
+        result.append(node)
+
+        for blocked in graph[node]["blocks"]:
+            in_degree[blocked] -= 1
+            if in_degree[blocked] == 0:
+                queue.append(blocked)
+
+    return result
+```
+
+### Detecting Circular Dependencies
+
+```python
+def has_cycle(graph):
+    visited = set()
+    rec_stack = set()
+
+    def dfs(node):
+        visited.add(node)
+        rec_stack.add(node)
+
+        for dep in graph[node]["depends_on"]:
+            if dep not in visited:
+                if dfs(dep):
+                    return True
+            elif dep in rec_stack:
+                return True
+
+        rec_stack.remove(node)
+        return False
+
+    for node in graph:
+        if node not in visited:
+            if dfs(node):
+                return True
+
+    return False
+```
+
+**If cycle detected:**
+```
+DEPENDENCY CYCLE DETECTED
+=========================
+
+Phases involved: 2A -> 3 -> 2A
+
+This plan has circular dependencies and cannot be executed.
+Please fix the plan's "Depends On" column.
+
+[EXIT - Invalid plan]
+```
+
+---
+
+## Execution Batching
+
+### Creating Execution Batches
+
+Group phases into sequential batches:
+
+```python
+def create_execution_batches(phases, parallel_groups):
+    batches = []
+    executed = set()
+    remaining = set(p.id for p in phases)
+
+    while remaining:
+        # Find phases whose dependencies are all met
+        ready = []
+        for phase_id in remaining:
+            deps = graph[phase_id]["depends_on"]
+            if all(d in executed for d in deps):
+                ready.append(phase_id)
+
+        if not ready:
+            raise Exception("Deadlock - unmet dependencies")
+
+        # Check if ready phases form a parallel group
+        for group in parallel_groups:
+            if set(group).issubset(set(ready)):
+                batches.append({"type": "parallel", "phases": group})
+                executed.update(group)
+                remaining -= set(group)
+                break
+        else:
+            # Execute first ready phase sequentially
+            phase = ready[0]
+            batches.append({"type": "sequential", "phases": [phase]})
+            executed.add(phase)
+            remaining.remove(phase)
+
+    return batches
+```
+
+### Example Batch Output
+
+```
+EXECUTION BATCHES
+=================
+
+Batch 1: sequential
+  - Phase 0 (Bootstrap)
+
+Batch 2: sequential
+  - Phase 1 (Setup)
+
+Batch 3: parallel
+  - Phase 2A (Backend)
+  - Phase 2B (Frontend)
+  - Phase 2C (Tests)
+
+Batch 4: sequential
+  - Phase 3 (Integration)
+```
+
+---
+
+## Execution Order Visualization
+
+### ASCII Diagram
+
+```
+EXECUTION ORDER
+===============
+
+[Phase 0: Bootstrap]
+        |
+        v
+[Phase 1: Setup]
+        |
+        +--------+--------+
+        |        |        |
+        v        v        v
+    [2A]     [2B]     [2C]     <- PARALLEL
+        |        |        |
+        +--------+--------+
+                |
+                v
+    [Phase 3: Integration]
+```
+
+### Mermaid Diagram (for plan documentation)
+
+```mermaid
+graph TD
+    P0[Phase 0: Bootstrap] --> P1[Phase 1: Setup]
+    P1 --> P2A[Phase 2A: Backend]
+    P1 --> P2B[Phase 2B: Frontend]
+    P1 --> P2C[Phase 2C: Tests]
+    P2A --> P3[Phase 3: Integration]
+    P2B --> P3
+    P2C --> P3
+
+    style P2A fill:#e1f5fe
+    style P2B fill:#e1f5fe
+    style P2C fill:#e1f5fe
+
+    subgraph parallel[Parallel Execution]
+        P2A
+        P2B
+        P2C
+    end
+```
+
+---
+
+## Phase Status Transitions
+
+```
+           +------------------+
+           |     pending      |
+           +--------+---------+
+                    |
+           (dependencies met)
+                    |
+                    v
+           +------------------+
+           |     running      |<----+
+           +--------+---------+     |
+                    |               |
+         +----------+----------+    |
+         |                     |    |
+    (success)             (failure) |
+         |                     |    |
+         v                     v    |
++------------------+  +------------------+
+|    complete      |  |     retry        |--+ (attempt < max)
++------------------+  +--------+---------+
+                               |
+                          (attempt >= max)
+                               |
+                               v
+                      +------------------+
+                      |     failed       |
+                      +------------------+
+```
+
+### Status Transition Rules
+
+| From | To | Condition |
+|------|-----|-----------|
+| pending | running | All dependencies complete |
+| running | complete | Sub-agent success + verification passed |
+| running | failed | Sub-agent failed + max retries reached |
+| failed | running | Resume with --resume (resets attempt count) |
+| complete | - | Terminal state |
+
+---
+
+## Handling Blocked Phases
+
+When a phase fails, update blocked phases:
+
+```python
+def update_blocked_phases(failed_phase, graph, states):
+    blocked = set()
+
+    def find_blocked(phase_id):
+        for downstream in graph[phase_id]["blocks"]:
+            if downstream not in blocked:
+                blocked.add(downstream)
+                states[downstream]["status"] = "blocked"
+                states[downstream]["error"] = {
+                    "type": "blocked",
+                    "message": f"Blocked by failed phase {failed_phase}"
+                }
+                find_blocked(downstream)
+
+    find_blocked(failed_phase)
+    return blocked
+```
+
+### Blocked Phase State
+
+```json
+{
+  "phase_id": "3",
+  "phase_name": "Integration",
+  "status": "blocked",
+  "error": {
+    "type": "blocked",
+    "message": "Blocked by failed phase 2a",
+    "blocking_phase": "2a"
+  }
+}
+```
+
+---
+
+## Resume Logic
+
+### Determining Resume Point
+
+```python
+def find_resume_point(states, batches):
+    for batch in batches:
+        for phase_id in batch["phases"]:
+            state = states.get(phase_id)
+            if not state:
+                return batch  # New phase
+            if state["status"] in ("pending", "failed", "running", "blocked"):
+                return batch
+
+    return None  # All complete
+```
+
+### Resume Scenarios
+
+| State | Resume Action |
+|-------|---------------|
+| Phase 2A: failed | Retry Phase 2A (reset attempt count) |
+| Phase 2A: running | Re-run Phase 2A (may have been interrupted) |
+| Phase 2A: complete, 2B: pending | Start Phase 2B |
+| Phase 3: blocked by 2A | First resume 2A |
+| All complete | Output completion summary |
+
+---
+
+## Parallel Execution
+
+### Launching Parallel Sub-Agents
+
+```
+LAUNCHING PARALLEL BATCH
+========================
+
+Phases: 2A, 2B, 2C
+Method: Concurrent Task tool calls with run_in_background: true
+
+Task 2A: [launched] -> task-id-abc
+Task 2B: [launched] -> task-id-def
+Task 2C: [launched] -> task-id-ghi
+
+Waiting for all tasks to complete...
+```
+
+### Collecting Parallel Results
+
+```python
+def execute_parallel_batch(phases):
+    # Launch all sub-agents
+    task_ids = {}
+    for phase in phases:
+        task_id = launch_subagent(phase, run_in_background=True)
+        task_ids[phase.id] = task_id
+
+    # Wait for all to complete
+    results = {}
+    for phase_id, task_id in task_ids.items():
+        result = wait_for_task(task_id)
+        results[phase_id] = result
+
+    return results
+```
+
+### Parallel Batch Completion
+
+```
+PARALLEL BATCH COMPLETE
+=======================
+
+Results:
+| Phase | Status | Duration |
+|-------|--------|----------|
+| 2A | complete | 10m 15s |
+| 2B | complete | 8m 30s |
+| 2C | complete | 5m 45s |
+
+All phases in batch successful.
+Proceeding to next batch...
+```
+
+### Partial Parallel Failure
+
+```
+PARALLEL BATCH PARTIAL FAILURE
+==============================
+
+Results:
+| Phase | Status | Duration |
+|-------|--------|----------|
+| 2A | FAILED | 15m 00s |
+| 2B | complete | 8m 30s |
+| 2C | complete | 5m 45s |
+
+Phase 2A failed. Initiating retry...
+
+[After retry]
+
+Phase 2A failed after retry.
+Successful phases (2B, 2C) preserved.
+Phase 3 blocked until 2A succeeds.
+
+AUTOBUILD HALTED
+```
+
+---
+
+## Dry Run Mode
+
+With `--dry-run` flag, validate and display without executing:
+
+```
+DRY RUN - EXECUTION PREVIEW
+============================
+
+Plan: docs/feature-plan.md
+Commit Mode: auto
+
+Stack Detection:
+- Language: TypeScript
+- Framework: Express
+- Tests: Jest
+
+Execution Order:
+
+Batch 1 (sequential):
+  [0] Bootstrap (5 pts)
+      Dependencies: none
+      Tasks: 4
+
+Batch 2 (sequential):
+  [1] Setup (3 pts)
+      Dependencies: [0]
+      Tasks: 3
+
+Batch 3 (parallel):
+  [2A] Backend (8 pts)
+       Dependencies: [1]
+       Tasks: 5
+  [2B] Frontend (5 pts)
+       Dependencies: [1]
+       Tasks: 4
+  [2C] Tests (3 pts)
+       Dependencies: [1]
+       Tasks: 3
+
+Batch 4 (sequential):
+  [3] Integration (5 pts)
+      Dependencies: [2A, 2B, 2C]
+      Tasks: 4
+
+Total: 6 phases, 24 points, 23 tasks
+
+Validation: PASSED
+Ready to execute with: /autobuild docs/feature-plan.md --commit=auto
+```

--- a/.claude/skills/autobuild/references/STATE-FILES.md
+++ b/.claude/skills/autobuild/references/STATE-FILES.md
@@ -1,0 +1,521 @@
+# State Files Reference
+
+> Complete specification for .autobuild/ directory structure and state file format.
+
+## Directory Structure
+
+```
+.autobuild/
+  config.json           # Execution configuration (stack, commands, args)
+  commits.sh            # Generated commit script (--commit=message-only)
+  phases/
+    phase-0.json        # State file per phase
+    phase-1.json
+    phase-2a.json       # Parallel phases use alpha suffix
+    phase-2b.json
+    phase-2c.json
+    phase-3.json
+    ...
+  logs/
+    execution.log       # Overall execution log
+    phase-0.log         # Truncated sub-agent output per phase
+    phase-1.log
+    ...
+```
+
+---
+
+## config.json
+
+Created during initialization, stores execution parameters.
+
+```json
+{
+  "version": "1.0.0",
+  "plan_path": "docs/feature-plan.md",
+  "commit_mode": "auto",
+  "started_at": "2025-01-25T10:00:00Z",
+  "last_updated": "2025-01-25T10:30:00Z",
+  "stack": {
+    "language": "typescript",
+    "framework": "express",
+    "package_manager": "pnpm",
+    "test_framework": "jest",
+    "linter": "eslint",
+    "formatter": "prettier"
+  },
+  "commands": {
+    "lint": "pnpm run lint",
+    "format": "pnpm run format:check",
+    "typecheck": "pnpm run typecheck",
+    "test": "pnpm test"
+  },
+  "phases": {
+    "total": 6,
+    "completed": 3,
+    "failed": 1,
+    "pending": 2
+  }
+}
+```
+
+### Config Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Autobuild state format version |
+| `plan_path` | string | Path to plan document |
+| `commit_mode` | enum | "auto", "message-only", or "single" |
+| `started_at` | ISO 8601 | Execution start time |
+| `last_updated` | ISO 8601 | Last state change time |
+| `stack` | object | Detected technology stack |
+| `commands` | object | Quality gate commands |
+| `phases` | object | Phase count summary |
+
+---
+
+## Phase State Files
+
+Each phase gets a state file: `.autobuild/phases/phase-{id}.json`
+
+### Phase Naming
+
+| Phase ID | State File |
+|----------|------------|
+| Phase 0 | `phase-0.json` |
+| Phase 1 | `phase-1.json` |
+| Phase 2A | `phase-2a.json` |
+| Phase 2B | `phase-2b.json` |
+| Phase 3 | `phase-3.json` |
+
+**Normalize phase IDs**: Remove spaces, lowercase, remove punctuation.
+
+### Complete Phase State Format
+
+```json
+{
+  "phase_id": "2a",
+  "phase_name": "Backend API",
+  "status": "complete",
+  "attempt": 1,
+  "max_attempts": 2,
+  "timestamps": {
+    "started": "2025-01-25T10:15:00Z",
+    "completed": "2025-01-25T10:25:00Z",
+    "duration_seconds": 600
+  },
+  "dependencies": {
+    "depends_on": ["1"],
+    "parallel_with": ["2b", "2c"],
+    "blocks": ["3"]
+  },
+  "execution": {
+    "subagent_id": "task-abc123",
+    "subagent_model": "sonnet",
+    "tasks_total": 4,
+    "tasks_completed": 4
+  },
+  "quality_gates": {
+    "lint": {
+      "passed": true,
+      "command": "pnpm run lint",
+      "output_summary": "No errors"
+    },
+    "format": {
+      "passed": true,
+      "command": "pnpm run format:check",
+      "output_summary": "All files formatted"
+    },
+    "typecheck": {
+      "passed": true,
+      "command": "pnpm run typecheck",
+      "output_summary": "No type errors"
+    },
+    "test": {
+      "passed": true,
+      "command": "pnpm test",
+      "output_summary": "47 tests passed, 0 failed",
+      "coverage": "87%"
+    }
+  },
+  "verification": {
+    "subagent_claimed": "complete",
+    "fresh_verification": "passed",
+    "verified_at": "2025-01-25T10:26:00Z"
+  },
+  "commit": {
+    "message": "feat(api): implement JWT token validation\n\n- Add validateToken function\n- Add token refresh endpoint\n- Add comprehensive test coverage",
+    "type": "feat",
+    "scope": "api",
+    "files_created": [
+      "src/api/auth.ts",
+      "src/api/auth.test.ts"
+    ],
+    "files_modified": [
+      "src/api/routes.ts"
+    ],
+    "files_deleted": [],
+    "committed": true,
+    "commit_sha": "a1b2c3d"
+  },
+  "plan_updates": {
+    "tasks_checked": 4,
+    "dod_checked": 6,
+    "status_updated": true
+  },
+  "error": null
+}
+```
+
+### Status Values
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Not yet started |
+| `running` | Sub-agent currently executing |
+| `complete` | Successfully finished and verified |
+| `failed` | Failed after max attempts |
+| `blocked` | Dependencies not met |
+
+### Minimal State (Pending Phase)
+
+```json
+{
+  "phase_id": "3",
+  "phase_name": "Integration",
+  "status": "pending",
+  "attempt": 0,
+  "max_attempts": 2,
+  "timestamps": {},
+  "dependencies": {
+    "depends_on": ["2a", "2b", "2c"],
+    "parallel_with": [],
+    "blocks": []
+  },
+  "execution": null,
+  "quality_gates": null,
+  "verification": null,
+  "commit": null,
+  "plan_updates": null,
+  "error": null
+}
+```
+
+### Failed Phase State
+
+```json
+{
+  "phase_id": "2a",
+  "phase_name": "Backend API",
+  "status": "failed",
+  "attempt": 2,
+  "max_attempts": 2,
+  "timestamps": {
+    "started": "2025-01-25T10:15:00Z",
+    "failed": "2025-01-25T10:35:00Z",
+    "duration_seconds": 1200
+  },
+  "dependencies": {
+    "depends_on": ["1"],
+    "parallel_with": ["2b", "2c"],
+    "blocks": ["3"]
+  },
+  "execution": {
+    "subagent_id": "task-xyz789",
+    "subagent_model": "sonnet",
+    "tasks_total": 4,
+    "tasks_completed": 2
+  },
+  "quality_gates": {
+    "lint": {
+      "passed": true,
+      "command": "pnpm run lint",
+      "output_summary": "No errors"
+    },
+    "format": {
+      "passed": true,
+      "command": "pnpm run format:check",
+      "output_summary": "All files formatted"
+    },
+    "typecheck": {
+      "passed": true,
+      "command": "pnpm run typecheck",
+      "output_summary": "No type errors"
+    },
+    "test": {
+      "passed": false,
+      "command": "pnpm test",
+      "output_summary": "3 tests failed",
+      "failures": [
+        "src/api/auth.test.ts:45 - should validate token",
+        "src/api/auth.test.ts:67 - should refresh token",
+        "src/api/auth.test.ts:89 - should handle expired token"
+      ]
+    }
+  },
+  "verification": {
+    "subagent_claimed": "complete",
+    "fresh_verification": "failed",
+    "verified_at": "2025-01-25T10:35:00Z"
+  },
+  "commit": null,
+  "plan_updates": null,
+  "error": {
+    "type": "test_failure",
+    "message": "3 tests failed after retry",
+    "details": "Tests in src/api/auth.test.ts failing on token validation logic",
+    "attempt_1_error": "3 tests failed - token validation incorrect",
+    "attempt_2_error": "3 tests failed - same failures after retry"
+  }
+}
+```
+
+---
+
+## Log Files
+
+### execution.log
+
+Overall execution log with timestamps:
+
+```
+[2025-01-25T10:00:00Z] AUTOBUILD STARTED
+[2025-01-25T10:00:00Z] Plan: docs/feature-plan.md
+[2025-01-25T10:00:00Z] Commit mode: auto
+[2025-01-25T10:00:01Z] Stack detected: typescript/express
+[2025-01-25T10:00:02Z] Phases identified: 6
+[2025-01-25T10:00:02Z] Execution order: [0] -> [1] -> [2a,2b,2c] -> [3]
+
+[2025-01-25T10:00:03Z] PHASE 0 STARTED
+[2025-01-25T10:05:00Z] PHASE 0 COMPLETE - chore(bootstrap): add quality tools
+[2025-01-25T10:05:01Z] Committed: a1b2c3d
+
+[2025-01-25T10:05:02Z] PHASE 1 STARTED
+[2025-01-25T10:10:00Z] PHASE 1 COMPLETE - feat(db): add user schema
+[2025-01-25T10:10:01Z] Committed: b2c3d4e
+
+[2025-01-25T10:10:02Z] PARALLEL BATCH STARTED: 2a, 2b, 2c
+[2025-01-25T10:25:00Z] PHASE 2B COMPLETE - feat(ui): add login form
+[2025-01-25T10:27:00Z] PHASE 2C COMPLETE - test(auth): add edge cases
+[2025-01-25T10:30:00Z] PHASE 2A FAILED - tests failing (attempt 1)
+[2025-01-25T10:30:01Z] PHASE 2A RETRY STARTED
+[2025-01-25T10:35:00Z] PHASE 2A FAILED - tests failing (attempt 2)
+[2025-01-25T10:35:01Z] PARALLEL BATCH FAILED: 2a failed, 2b+2c complete
+
+[2025-01-25T10:35:02Z] AUTOBUILD HALTED
+[2025-01-25T10:35:02Z] Completed: 4 phases
+[2025-01-25T10:35:02Z] Failed: 1 phase (2a)
+[2025-01-25T10:35:02Z] Remaining: 1 phase (3)
+```
+
+### phase-{id}.log
+
+Truncated sub-agent conversation for debugging:
+
+```
+=== PHASE 2A SUB-AGENT LOG ===
+Started: 2025-01-25T10:15:00Z
+Model: sonnet
+
+--- TASK 1: Create auth types ---
+[Reading plan section...]
+[Writing test: src/api/auth.test.ts]
+[Running test - expected FAIL]
+[Writing implementation: src/api/auth.ts]
+[Running test - PASS]
+
+--- TASK 2: Implement validateToken ---
+[Writing test...]
+[Running test - expected FAIL]
+[Writing implementation...]
+[Running test - PASS]
+
+--- QUALITY GATES ---
+Lint: pnpm run lint -> PASS
+Format: pnpm run format:check -> PASS
+Typecheck: pnpm run typecheck -> PASS
+Tests: pnpm test -> PASS (47 tests)
+
+--- PLAN UPDATES ---
+Checked: 4 tasks
+DoD: 6 items
+
+--- RESULT ---
+Status: complete
+Commit: feat(api): implement JWT token validation
+
+=== END PHASE 2A LOG ===
+```
+
+---
+
+## commits.sh (--commit=message-only)
+
+Generated script for manual commit execution:
+
+```bash
+#!/bin/bash
+# Generated by autobuild
+# Plan: docs/feature-plan.md
+# Generated: 2025-01-25T10:35:00Z
+
+set -e
+
+echo "Committing Phase 0: Bootstrap"
+git add .eslintrc.json .prettierrc tsconfig.json jest.config.js
+git commit -m "$(cat <<'EOF'
+chore(bootstrap): add quality tools
+
+- Add ESLint configuration
+- Add Prettier configuration
+- Add TypeScript configuration
+- Add Jest configuration
+EOF
+)"
+
+echo "Committing Phase 1: Setup"
+git add prisma/schema.prisma prisma/migrations/
+git commit -m "$(cat <<'EOF'
+feat(db): add user schema
+
+- Create user model with auth fields
+- Add initial migration
+EOF
+)"
+
+echo "Committing Phase 2A: Backend API"
+git add src/api/auth.ts src/api/auth.test.ts src/api/routes.ts
+git commit -m "$(cat <<'EOF'
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+
+# ... more phases ...
+
+echo "All commits complete!"
+```
+
+---
+
+## State File Operations
+
+### Creating State File
+
+```python
+# Pseudocode for state file creation
+def create_phase_state(phase_id, phase_name, dependencies):
+    return {
+        "phase_id": normalize_id(phase_id),
+        "phase_name": phase_name,
+        "status": "pending",
+        "attempt": 0,
+        "max_attempts": 2,
+        "timestamps": {},
+        "dependencies": dependencies,
+        "execution": None,
+        "quality_gates": None,
+        "verification": None,
+        "commit": None,
+        "plan_updates": None,
+        "error": None
+    }
+```
+
+### Updating State File
+
+```python
+# Pseudocode for state update
+def update_phase_state(state_file, updates):
+    state = read_json(state_file)
+    state.update(updates)
+    state["timestamps"]["last_updated"] = now_iso()
+    write_json(state_file, state)
+```
+
+### Reading State for Resume
+
+```python
+# Pseudocode for resume logic
+def get_resume_point():
+    states = read_all_phase_states()
+
+    for phase in topological_order(states):
+        if phase["status"] == "pending":
+            return phase["phase_id"]
+        if phase["status"] == "failed":
+            return phase["phase_id"]  # Retry failed phase
+        if phase["status"] == "running":
+            return phase["phase_id"]  # Resume interrupted
+
+    return None  # All complete
+```
+
+---
+
+## Gitignore Recommendation
+
+Add to `.gitignore`:
+
+```gitignore
+# Autobuild state (optional - some teams prefer to track)
+.autobuild/
+
+# Or keep state but ignore logs
+# .autobuild/logs/
+```
+
+**Arguments for tracking .autobuild/:**
+- Preserves execution history
+- Enables team visibility into build progress
+- Supports debugging failed builds
+
+**Arguments against tracking:**
+- State is ephemeral and regenerable
+- Can contain large log files
+- May conflict between team members
+
+---
+
+## State File Validation
+
+Before using state files, validate:
+
+```json
+{
+  "required_fields": [
+    "phase_id",
+    "phase_name",
+    "status",
+    "attempt",
+    "max_attempts"
+  ],
+  "valid_statuses": [
+    "pending",
+    "running",
+    "complete",
+    "failed",
+    "blocked"
+  ]
+}
+```
+
+If validation fails, treat state as corrupted and prompt user:
+
+```
+STATE FILE VALIDATION FAILED
+============================
+
+File: .autobuild/phases/phase-2a.json
+Error: Missing required field 'status'
+
+Options:
+1. Delete corrupted state and re-run phase
+2. Manually fix state file
+3. Start fresh with --fresh flag
+
+[WAITING FOR USER INPUT]
+```

--- a/.claude/skills/autobuild/references/SUBAGENT-PROMPTS.md
+++ b/.claude/skills/autobuild/references/SUBAGENT-PROMPTS.md
@@ -1,0 +1,508 @@
+# Sub-Agent Prompts Reference
+
+> Exact prompts for launching phase execution sub-agents. Copy these templates exactly.
+
+## Core Principle
+
+Each phase runs in its own sub-agent to:
+1. **Isolate context** - Sub-agent starts fresh, no accumulated context
+2. **Enable parallelism** - Multiple sub-agents can run concurrently
+3. **Prevent exhaustion** - Main agent context stays minimal
+4. **Support recovery** - Failed sub-agent doesn't corrupt main state
+
+---
+
+## Sequential Phase Prompt
+
+Use this exact template for sequential phases:
+
+```
+You are executing Phase {PHASE_ID} of an implementation plan.
+
+═══════════════════════════════════════════════════════════════
+PHASE DETAILS
+═══════════════════════════════════════════════════════════════
+
+Phase ID: {PHASE_ID}
+Phase Name: {PHASE_NAME}
+Plan File: {PLAN_PATH}
+
+═══════════════════════════════════════════════════════════════
+YOUR TASK
+═══════════════════════════════════════════════════════════════
+
+1. Read the plan file at {PLAN_PATH}
+2. Find the section for Phase {PHASE_ID}: {PHASE_NAME}
+3. Execute EACH task following the 5-step TDD micro-structure:
+   - Step 1: Write the failing test
+   - Step 2: Run test, verify it FAILS (mandatory - must see failure)
+   - Step 3: Write minimal implementation
+   - Step 4: Run test, verify it PASSES (mandatory - must see pass)
+   - Step 5: Stage files (do not commit)
+
+4. After ALL tasks complete, run quality gates:
+   - Lint: {LINT_COMMAND}
+   - Format: {FORMAT_COMMAND}
+   - Typecheck: {TYPECHECK_COMMAND}
+   - Test: {TEST_COMMAND}
+
+5. Update the plan file:
+   - Check off completed tasks (- [ ] -> - [x])
+   - Check off Definition of Done items
+   - Update phase status in overview table (if present)
+
+═══════════════════════════════════════════════════════════════
+CRITICAL RULES
+═══════════════════════════════════════════════════════════════
+
+- Do NOT skip the TDD cycle - tests MUST fail first
+- Do NOT run git commit commands
+- Do NOT modify other phases
+- Do NOT proceed if quality gates fail
+- STOP immediately if you cannot complete a task
+
+═══════════════════════════════════════════════════════════════
+RETURN FORMAT (JSON)
+═══════════════════════════════════════════════════════════════
+
+When complete, output EXACTLY this JSON structure:
+
+```json
+{
+  "phase_id": "{PHASE_ID}",
+  "status": "complete" | "failed",
+  "tasks": {
+    "total": <number>,
+    "completed": <number>
+  },
+  "quality_gates": {
+    "lint": {"passed": true|false, "output": "<summary>"},
+    "format": {"passed": true|false, "output": "<summary>"},
+    "typecheck": {"passed": true|false, "output": "<summary>"},
+    "test": {"passed": true|false, "output": "<summary>", "count": <number>}
+  },
+  "commit_message": "<conventional commit message>",
+  "files": {
+    "created": ["path/to/file.ts", ...],
+    "modified": ["path/to/file.ts", ...],
+    "deleted": []
+  },
+  "plan_updated": true|false,
+  "error": null | {"type": "<type>", "message": "<details>"}
+}
+```
+
+Begin execution now.
+```
+
+---
+
+## Parallel Phase Prompt
+
+Use this for phases in a parallel batch. Identical to sequential but emphasizes isolation:
+
+```
+You are executing Phase {PHASE_ID} of an implementation plan.
+
+THIS IS A PARALLEL PHASE - Other phases ({SIBLING_PHASES}) are running concurrently.
+Do NOT modify files that belong to sibling phases.
+
+═══════════════════════════════════════════════════════════════
+PHASE DETAILS
+═══════════════════════════════════════════════════════════════
+
+Phase ID: {PHASE_ID}
+Phase Name: {PHASE_NAME}
+Plan File: {PLAN_PATH}
+Parallel With: {SIBLING_PHASES}
+
+═══════════════════════════════════════════════════════════════
+YOUR TASK
+═══════════════════════════════════════════════════════════════
+
+1. Read the plan file at {PLAN_PATH}
+2. Find the section for Phase {PHASE_ID}: {PHASE_NAME}
+3. Execute EACH task following the 5-step TDD micro-structure:
+   - Step 1: Write the failing test
+   - Step 2: Run test, verify it FAILS (mandatory - must see failure)
+   - Step 3: Write minimal implementation
+   - Step 4: Run test, verify it PASSES (mandatory - must see pass)
+   - Step 5: Stage files (do not commit)
+
+4. After ALL tasks complete, run quality gates:
+   - Lint: {LINT_COMMAND}
+   - Format: {FORMAT_COMMAND}
+   - Typecheck: {TYPECHECK_COMMAND}
+   - Test: {TEST_COMMAND}
+
+5. Update the plan file:
+   - Check off completed tasks for YOUR PHASE ONLY
+   - Check off Definition of Done items for YOUR PHASE ONLY
+   - Update YOUR phase status in overview table
+
+═══════════════════════════════════════════════════════════════
+PARALLEL EXECUTION RULES
+═══════════════════════════════════════════════════════════════
+
+- ONLY modify files listed in YOUR phase section
+- Do NOT touch files that sibling phases might be editing
+- If you need a shared file, coordinate via imports only
+- Siblings phases are: {SIBLING_PHASES}
+
+═══════════════════════════════════════════════════════════════
+CRITICAL RULES
+═══════════════════════════════════════════════════════════════
+
+- Do NOT skip the TDD cycle - tests MUST fail first
+- Do NOT run git commit commands
+- Do NOT modify other phases
+- Do NOT proceed if quality gates fail
+- STOP immediately if you cannot complete a task
+
+═══════════════════════════════════════════════════════════════
+RETURN FORMAT (JSON)
+═══════════════════════════════════════════════════════════════
+
+When complete, output EXACTLY this JSON structure:
+
+```json
+{
+  "phase_id": "{PHASE_ID}",
+  "status": "complete" | "failed",
+  "tasks": {
+    "total": <number>,
+    "completed": <number>
+  },
+  "quality_gates": {
+    "lint": {"passed": true|false, "output": "<summary>"},
+    "format": {"passed": true|false, "output": "<summary>"},
+    "typecheck": {"passed": true|false, "output": "<summary>"},
+    "test": {"passed": true|false, "output": "<summary>", "count": <number>}
+  },
+  "commit_message": "<conventional commit message>",
+  "files": {
+    "created": ["path/to/file.ts", ...],
+    "modified": ["path/to/file.ts", ...],
+    "deleted": []
+  },
+  "plan_updated": true|false,
+  "error": null | {"type": "<type>", "message": "<details>"}
+}
+```
+
+Begin execution now.
+```
+
+---
+
+## Retry Phase Prompt
+
+When retrying a failed phase, include context about the previous failure:
+
+```
+You are RETRYING Phase {PHASE_ID} of an implementation plan.
+
+═══════════════════════════════════════════════════════════════
+RETRY CONTEXT
+═══════════════════════════════════════════════════════════════
+
+This is attempt {ATTEMPT} of {MAX_ATTEMPTS}.
+
+Previous failure:
+  Type: {PREVIOUS_ERROR_TYPE}
+  Message: {PREVIOUS_ERROR_MESSAGE}
+  Details: {PREVIOUS_ERROR_DETAILS}
+
+You must address the previous failure while completing the phase.
+
+═══════════════════════════════════════════════════════════════
+PHASE DETAILS
+═══════════════════════════════════════════════════════════════
+
+Phase ID: {PHASE_ID}
+Phase Name: {PHASE_NAME}
+Plan File: {PLAN_PATH}
+
+═══════════════════════════════════════════════════════════════
+YOUR TASK
+═══════════════════════════════════════════════════════════════
+
+1. Read the plan file at {PLAN_PATH}
+2. Find the section for Phase {PHASE_ID}: {PHASE_NAME}
+3. Review what was already done (check plan for [x] items)
+4. Focus on fixing the previous failure:
+   {RETRY_GUIDANCE}
+
+5. Complete any remaining tasks using TDD micro-structure
+6. Run ALL quality gates (even if some passed before)
+7. Update plan file with any newly completed items
+
+═══════════════════════════════════════════════════════════════
+CRITICAL RULES
+═══════════════════════════════════════════════════════════════
+
+- Do NOT skip the TDD cycle - tests MUST fail first
+- Do NOT run git commit commands
+- Do NOT modify other phases
+- Do NOT proceed if quality gates fail
+- STOP immediately if you cannot complete a task
+
+═══════════════════════════════════════════════════════════════
+RETURN FORMAT (JSON)
+═══════════════════════════════════════════════════════════════
+
+[Same JSON format as above]
+
+Begin retry now.
+```
+
+### Retry Guidance by Error Type
+
+| Error Type | Retry Guidance |
+|------------|----------------|
+| `test_failure` | "Fix the failing tests. Read the error messages carefully. The tests at {FILES} are failing." |
+| `lint_error` | "Fix linting errors. Run `{LINT_COMMAND}` to see current errors." |
+| `typecheck_error` | "Fix type errors. Run `{TYPECHECK_COMMAND}` to see current errors." |
+| `format_error` | "Run `{FORMAT_FIX_COMMAND}` to auto-fix formatting, then verify." |
+| `task_incomplete` | "Task {TASK_NAME} was not completed. Review the plan and finish it." |
+| `verification_mismatch` | "Previous sub-agent claimed success but verification failed. Re-run all quality gates carefully." |
+
+---
+
+## Task Tool Invocation
+
+### Sequential Phase
+
+```python
+# Pseudocode for launching sequential phase sub-agent
+result = Task(
+    description=f"Execute Phase {phase_id}",
+    prompt=format_sequential_prompt(phase, config),
+    subagent_type="general-purpose",
+    model="sonnet",  # Or inherit from config
+    run_in_background=False  # Wait for completion
+)
+```
+
+### Parallel Phases
+
+```python
+# Pseudocode for launching parallel phase sub-agents
+task_ids = []
+
+for phase in parallel_batch:
+    task_id = Task(
+        description=f"Execute Phase {phase.id}",
+        prompt=format_parallel_prompt(phase, parallel_batch, config),
+        subagent_type="general-purpose",
+        model="sonnet",
+        run_in_background=True  # Don't wait
+    )
+    task_ids.append((phase.id, task_id))
+
+# Collect results
+results = {}
+for phase_id, task_id in task_ids:
+    result = TaskOutput(task_id=task_id, block=True, timeout=600000)
+    results[phase_id] = parse_result(result)
+```
+
+---
+
+## Result Parsing
+
+### Extracting JSON from Sub-Agent Output
+
+Sub-agents may include text before/after the JSON. Extract carefully:
+
+```python
+def parse_subagent_result(output):
+    # Find JSON block in output
+    import json
+    import re
+
+    # Look for JSON between ```json and ``` markers
+    json_match = re.search(r'```json\s*(.*?)\s*```', output, re.DOTALL)
+    if json_match:
+        return json.loads(json_match.group(1))
+
+    # Try finding raw JSON object
+    json_match = re.search(r'\{[\s\S]*"phase_id"[\s\S]*\}', output)
+    if json_match:
+        return json.loads(json_match.group(0))
+
+    raise ParseError("Could not extract JSON result from sub-agent output")
+```
+
+### Validating Result Structure
+
+```python
+def validate_result(result):
+    required_fields = [
+        "phase_id",
+        "status",
+        "tasks",
+        "quality_gates",
+        "commit_message",
+        "files",
+        "plan_updated"
+    ]
+
+    for field in required_fields:
+        if field not in result:
+            raise ValidationError(f"Missing required field: {field}")
+
+    if result["status"] not in ("complete", "failed"):
+        raise ValidationError(f"Invalid status: {result['status']}")
+
+    return True
+```
+
+---
+
+## Commit Message Guidelines
+
+Sub-agents generate commit messages following Conventional Commits:
+
+### Message Format
+
+```
+<type>(<scope>): <description>
+
+<body>
+```
+
+### Type Selection
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New feature for users |
+| `fix` | Bug fix |
+| `refactor` | Code restructure (no behavior change) |
+| `test` | Adding/updating tests |
+| `docs` | Documentation only |
+| `chore` | Build, config, dependencies |
+
+### Scope Derivation
+
+Derive scope from file paths:
+
+```
+src/api/auth.ts -> scope: api or auth
+src/components/Button.tsx -> scope: ui or button
+tests/unit/auth.test.ts -> scope: auth
+```
+
+### Example Messages
+
+```
+feat(api): add user authentication endpoints
+
+- Implement login endpoint with JWT
+- Add token refresh functionality
+- Add logout endpoint
+```
+
+```
+test(auth): add comprehensive auth test coverage
+
+- Add unit tests for token validation
+- Add integration tests for login flow
+- Add edge case tests for expired tokens
+```
+
+---
+
+## Error Handling in Sub-Agents
+
+### Sub-Agent Failure Response
+
+If a sub-agent cannot complete, it should return:
+
+```json
+{
+  "phase_id": "2a",
+  "status": "failed",
+  "tasks": {
+    "total": 5,
+    "completed": 2
+  },
+  "quality_gates": {
+    "lint": {"passed": true, "output": "No errors"},
+    "format": {"passed": true, "output": "All formatted"},
+    "typecheck": {"passed": true, "output": "No errors"},
+    "test": {"passed": false, "output": "3 tests failed", "count": 47}
+  },
+  "commit_message": null,
+  "files": {
+    "created": ["src/api/auth.ts"],
+    "modified": [],
+    "deleted": []
+  },
+  "plan_updated": false,
+  "error": {
+    "type": "test_failure",
+    "message": "3 tests failing in auth.test.ts",
+    "details": "Tests for token validation returning incorrect results. Expected user object, got null."
+  }
+}
+```
+
+### Sub-Agent Timeout
+
+If sub-agent doesn't respond within timeout:
+
+```
+SUB-AGENT TIMEOUT
+=================
+
+Phase: 2A
+Timeout: 10 minutes exceeded
+
+Actions taken:
+1. Sub-agent task terminated
+2. State file updated with timeout error
+3. Phase marked as failed
+
+Error recorded:
+{
+  "type": "timeout",
+  "message": "Sub-agent did not complete within 10 minutes",
+  "details": "Task may be stuck or too complex. Consider breaking into smaller tasks."
+}
+
+Initiating retry...
+```
+
+---
+
+## Sub-Agent Context Loading
+
+Sub-agents should load context efficiently:
+
+### What to Read
+
+1. **Plan file** - Specific phase section only
+2. **Referenced files** - Files mentioned in task descriptions
+3. **Test files** - To understand existing test patterns
+
+### What NOT to Read
+
+1. Other phase sections (unless explicit dependency)
+2. Entire codebase exploration
+3. Documentation files (unless task requires)
+4. Previous conversation history (isolated by design)
+
+### Efficient Context Pattern
+
+```
+# Good: Targeted reads
+Read: docs/feature-plan.md (find Phase 2A section)
+Read: src/api/routes.ts (modify target)
+Read: tests/api/routes.test.ts (test pattern reference)
+
+# Bad: Exploratory reads
+Read: src/**/*.ts (too broad)
+Grep: "function" (unfocused search)
+Read: README.md (not needed for execution)
+```

--- a/.claude/skills/autobuild/references/VERIFICATION.md
+++ b/.claude/skills/autobuild/references/VERIFICATION.md
@@ -1,0 +1,546 @@
+# Verification Reference
+
+> Fresh verification after sub-agent completion and commit handling by mode.
+
+## Trust But Verify Principle
+
+**Sub-agent claims are reports, not evidence.**
+
+After a sub-agent reports success, the main agent MUST independently verify:
+1. All quality gates pass
+2. Plan file was actually updated
+3. Expected files exist
+
+This catches:
+- Sub-agent hallucinations
+- Partial completions reported as success
+- Quality gate regressions from parallel work
+
+---
+
+## Fresh Verification Sequence
+
+```
+VERIFICATION SEQUENCE
+=====================
+
+1. COLLECT sub-agent result JSON
+2. PARSE status and quality gate claims
+3. RUN each quality gate command fresh
+4. COMPARE fresh results to claims
+5. VERIFY plan file updates exist
+6. VERIFY files created/modified exist
+7. DETERMINE true pass/fail status
+```
+
+### Verification Output Format
+
+```
+VERIFICATION - Phase {PHASE_ID}
+===============================
+
+Sub-agent claimed: {STATUS}
+
+Running fresh verification...
+
+Quality Gates:
+┌────────────┬─────────┬─────────────────────────────┐
+│ Check      │ Result  │ Output                      │
+├────────────┼─────────┼─────────────────────────────┤
+│ Lint       │ PASS    │ No errors                   │
+│ Format     │ PASS    │ All files formatted         │
+│ Typecheck  │ PASS    │ No type errors              │
+│ Test       │ PASS    │ 47 passed, 0 failed         │
+└────────────┴─────────┴─────────────────────────────┘
+
+Plan Updates:
+- Tasks checked: YES (4/4 items)
+- DoD checked: YES (6/6 items)
+- Status updated: YES (⬜ -> ✅)
+
+Files:
+- Created: 2/2 exist
+- Modified: 1/1 exist
+
+VERIFICATION: PASSED
+```
+
+---
+
+## Running Quality Gates
+
+### Command Execution
+
+Run each quality gate command and capture output:
+
+```python
+def run_quality_gate(name, command, timeout=120):
+    result = Bash(
+        command=command,
+        timeout=timeout * 1000,
+        description=f"Verify {name}"
+    )
+
+    return {
+        "name": name,
+        "command": command,
+        "passed": result.exit_code == 0,
+        "output": result.output[:500],  # Truncate for state file
+        "exit_code": result.exit_code
+    }
+```
+
+### Stack-Specific Commands
+
+| Stack | Lint | Format | Typecheck | Test |
+|-------|------|--------|-----------|------|
+| TypeScript/Node | `npm run lint` | `npm run format:check` | `npm run typecheck` or `npx tsc --noEmit` | `npm test` |
+| Python | `ruff check .` or `pylint src` | `black --check .` or `ruff format --check .` | `mypy .` or `pyright` | `pytest` |
+| Go | `golangci-lint run` | `test -z "$(gofmt -l .)"` | `go build ./...` | `go test ./...` |
+| Rust | `cargo clippy` | `cargo fmt --check` | `cargo check` | `cargo test` |
+
+### Handling Missing Tools
+
+If a quality gate command fails with "command not found":
+
+```
+QUALITY GATE UNAVAILABLE
+========================
+
+Check: Lint
+Command: npm run lint
+Error: Script "lint" not found in package.json
+
+Options:
+1. Skip this check (record as N/A)
+2. Halt and require tool setup
+
+Proceeding with skip...
+
+Note: Skipped checks will be marked in state file.
+```
+
+---
+
+## Verification Mismatch Handling
+
+### Sub-Agent Claimed Success, Verification Fails
+
+```
+VERIFICATION MISMATCH
+=====================
+
+Sub-agent claimed: complete
+Fresh verification: FAILED
+
+Discrepancy:
+┌────────────┬───────────────┬─────────────────┐
+│ Check      │ Sub-agent     │ Fresh Result    │
+├────────────┼───────────────┼─────────────────┤
+│ Lint       │ passed        │ FAILED (3 err)  │
+│ Test       │ 47 passed     │ FAILED (2 fail) │
+└────────────┴───────────────┴─────────────────┘
+
+This indicates a sub-agent error. Common causes:
+1. Sub-agent ran checks before final changes
+2. Sub-agent hallucinated passing results
+3. Parallel phase caused regression
+
+Action: Treating as phase FAILURE. Initiating retry...
+```
+
+### Sub-Agent Claimed Failure, Verification Passes
+
+Rare but possible (sub-agent was too pessimistic):
+
+```
+VERIFICATION UPGRADE
+====================
+
+Sub-agent claimed: failed
+Fresh verification: PASSED
+
+All quality gates pass. Possible causes:
+1. Sub-agent made fixes after reporting failure
+2. Sub-agent misread output
+3. Flaky test passed on retry
+
+Action: Accepting as SUCCESS (verification is authoritative)
+```
+
+---
+
+## Plan Update Verification
+
+### Checking Task Completion
+
+```python
+def verify_plan_updates(plan_path, phase_id, expected_tasks):
+    plan_content = Read(plan_path)
+
+    # Find phase section
+    phase_section = extract_phase_section(plan_content, phase_id)
+
+    # Count checked items
+    checked = phase_section.count("- [x]")
+    unchecked = phase_section.count("- [ ]")
+
+    return {
+        "tasks_checked": checked,
+        "tasks_unchecked": unchecked,
+        "expected": expected_tasks,
+        "all_complete": unchecked == 0 and checked >= expected_tasks
+    }
+```
+
+### Plan Update Failure
+
+If plan wasn't updated:
+
+```
+PLAN UPDATE VERIFICATION FAILED
+===============================
+
+Phase: 2A
+Expected: 4 tasks checked
+Found: 2 tasks checked, 2 unchecked
+
+Sub-agent did not complete plan updates.
+
+Action: Main agent will update plan file directly.
+```
+
+Main agent then updates the plan:
+
+```python
+# Update remaining checkboxes
+for task in unchecked_tasks:
+    Edit(
+        file_path=plan_path,
+        old_string=f"- [ ] {task}",
+        new_string=f"- [x] {task}"
+    )
+```
+
+---
+
+## File Existence Verification
+
+### Checking Created Files
+
+```python
+def verify_files_exist(files_created, files_modified):
+    missing = []
+
+    for file_path in files_created + files_modified:
+        try:
+            Read(file_path, limit=1)  # Just check existence
+        except FileNotFoundError:
+            missing.append(file_path)
+
+    return {
+        "all_exist": len(missing) == 0,
+        "missing": missing
+    }
+```
+
+### Missing Files Response
+
+```
+FILE VERIFICATION FAILED
+========================
+
+Expected files from sub-agent result:
+- src/api/auth.ts (MISSING)
+- src/api/auth.test.ts (EXISTS)
+
+Sub-agent claimed to create src/api/auth.ts but file does not exist.
+
+Action: Treating as phase FAILURE. Initiating retry...
+```
+
+---
+
+## Commit Handling by Mode
+
+### --commit=auto
+
+Auto-commit after verification passes:
+
+```
+VERIFICATION PASSED - AUTO-COMMIT
+=================================
+
+Staging files:
+  git add src/api/auth.ts src/api/auth.test.ts src/api/routes.ts
+
+Creating commit:
+  git commit -m "$(cat <<'EOF'
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+
+Commit created: a1b2c3d
+
+State file updated with commit SHA.
+```
+
+### Git Add Strategy
+
+Stage only files reported by sub-agent:
+
+```python
+def stage_files(files_created, files_modified):
+    all_files = files_created + files_modified
+
+    # Stage specific files, not "git add ."
+    if all_files:
+        file_list = " ".join(f'"{f}"' for f in all_files)
+        Bash(command=f"git add {file_list}")
+```
+
+### Commit Message Sanitization
+
+Ensure commit message is shell-safe:
+
+```python
+def sanitize_commit_message(message):
+    # Remove dangerous characters
+    dangerous = ['"', '`', '$', '!', '\\', ';', '&', '|', '>', '<', '*', '?']
+    for char in dangerous:
+        message = message.replace(char, '')
+
+    # Ensure proper line endings
+    message = message.replace('\r\n', '\n')
+
+    return message.strip()
+```
+
+### HEREDOC Commit Format
+
+Always use HEREDOC for multi-line commits:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+```
+
+### --commit=message-only
+
+Save message to state file and accumulate to commits.sh:
+
+```
+VERIFICATION PASSED - MESSAGE SAVED
+===================================
+
+Commit message for Phase 2A:
+
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+
+Files to commit:
+- src/api/auth.ts (CREATE)
+- src/api/auth.test.ts (CREATE)
+- src/api/routes.ts (MODIFY)
+
+Saved to: .autobuild/phases/phase-2a.json
+Appended to: .autobuild/commits.sh
+
+User handles git operations.
+```
+
+### Commits.sh Accumulation
+
+Append each phase's commit to the script:
+
+```python
+def append_to_commits_script(phase_id, commit_message, files):
+    script_path = ".autobuild/commits.sh"
+
+    commit_block = f'''
+echo "Committing Phase {phase_id}..."
+git add {" ".join(files)}
+git commit -m "$(cat <<'EOF'
+{commit_message}
+EOF
+)"
+'''
+
+    # Append to existing script
+    with open(script_path, "a") as f:
+        f.write(commit_block)
+```
+
+### --commit=single
+
+Queue commit for final combined message:
+
+```
+VERIFICATION PASSED - COMMIT QUEUED
+===================================
+
+Phase 2A complete.
+Commit message queued for final combined commit.
+
+Queued commits: 3 of 6 phases
+
+Continuing to next phase...
+```
+
+### Combined Commit at Completion
+
+When all phases complete with --commit=single:
+
+```
+COMBINED COMMIT
+===============
+
+All 6 phases complete. Creating combined commit...
+
+Files to commit:
+- .eslintrc.json (CREATE)
+- .prettierrc (CREATE)
+- prisma/schema.prisma (CREATE)
+- src/api/auth.ts (CREATE)
+- src/api/auth.test.ts (CREATE)
+- src/components/Login.tsx (CREATE)
+- [... more files ...]
+
+Combined commit message:
+
+feat(auth): implement complete authentication system
+
+Phases completed:
+- Phase 0: Bootstrap - quality tools configuration
+- Phase 1: Setup - database schema and migrations
+- Phase 2A: Backend - authentication API endpoints
+- Phase 2B: Frontend - login and registration UI
+- Phase 2C: Tests - comprehensive test coverage
+- Phase 3: Integration - end-to-end wiring
+
+Files changed: 24
+Tests added: 47
+
+git add .
+git commit -m "$(cat <<'EOF'
+feat(auth): implement complete authentication system
+
+Phases completed:
+- Phase 0: Bootstrap - quality tools configuration
+- Phase 1: Setup - database schema and migrations
+- Phase 2A: Backend - authentication API endpoints
+- Phase 2B: Frontend - login and registration UI
+- Phase 2C: Tests - comprehensive test coverage
+- Phase 3: Integration - end-to-end wiring
+
+Files changed: 24
+Tests added: 47
+EOF
+)"
+```
+
+---
+
+## Verification Timeout Handling
+
+If verification commands hang:
+
+```
+VERIFICATION TIMEOUT
+====================
+
+Check: Test
+Command: npm test
+Timeout: 5 minutes exceeded
+
+Possible causes:
+1. Tests are hanging (infinite loop, unresolved promise)
+2. Tests are very slow
+3. External dependency is down
+
+Action: Treating as verification FAILURE.
+
+Note: The sub-agent may have completed successfully, but we cannot
+verify without passing quality gates. Initiating retry...
+```
+
+---
+
+## Parallel Phase Verification
+
+For parallel phases, verify each independently then check for conflicts:
+
+```
+PARALLEL VERIFICATION
+=====================
+
+Phase 2A:
+- Quality gates: PASS
+- Files: 2 created, 1 modified
+
+Phase 2B:
+- Quality gates: PASS
+- Files: 3 created, 0 modified
+
+Phase 2C:
+- Quality gates: PASS
+- Files: 2 created, 0 modified
+
+Conflict Check:
+- No overlapping file modifications
+- All tests still pass together
+
+PARALLEL BATCH: VERIFIED
+```
+
+### Detecting Parallel Conflicts
+
+```python
+def check_parallel_conflicts(results):
+    all_files = {}
+
+    for phase_id, result in results.items():
+        modified = result["files"]["modified"]
+        for file in modified:
+            if file in all_files:
+                return {
+                    "conflict": True,
+                    "file": file,
+                    "phases": [all_files[file], phase_id]
+                }
+            all_files[file] = phase_id
+
+    return {"conflict": False}
+```
+
+### Conflict Response
+
+```
+PARALLEL CONFLICT DETECTED
+==========================
+
+File: src/api/routes.ts
+Modified by: Phase 2A AND Phase 2B
+
+Both phases modified the same file. This may cause merge conflicts.
+
+Resolution options:
+1. Manual merge required
+2. Re-run phases sequentially
+3. Abort and fix plan
+
+AUTOBUILD HALTED - Parallel conflict
+```

--- a/.codex/skills/adversarial-plan-review
+++ b/.codex/skills/adversarial-plan-review
@@ -1,0 +1,1 @@
+/Users/adamcobb/.agents/skulto/repositories/refactornator/adversarial-plan-review

--- a/.codex/skills/autobuild/SKILL.md
+++ b/.codex/skills/autobuild/SKILL.md
@@ -1,0 +1,778 @@
+---
+name: autobuild
+description: Autonomous single-shot plan execution. Runs entire superplan implementation plans without stopping, using sub-agents for each phase. Phases write state to filesystem for resume capability. Sequential phases run in order, parallel phases (1a, 1b) run concurrently. User never needs to compact context.
+metadata:
+  version: "1.0.0"
+  author: skulto
+compatibility: Requires plan document in superplan format. Sub-agents execute phases independently. State persisted to .autobuild/ directory.
+---
+
+# Autobuild: Autonomous Plan Execution Engine
+
+Execute entire implementation plans in a single pass with zero user intervention. Each phase runs in its own sub-agent, writing state to the filesystem. Context never exhausts because sub-agents are isolated.
+
+## Overview
+
+Autobuild is an **autonomous execution engine** for superplan implementation plans. Unlike `superbuild` which stops after each phase for user confirmation, autobuild runs everything to completion.
+
+**Key Differences from superbuild:**
+
+| Aspect | superbuild | autobuild |
+|--------|------------|-----------|
+| Execution | Phase-by-phase with stops | Continuous until complete |
+| User intervention | Required after each phase | None (fully autonomous) |
+| Context management | Manual compaction | Sub-agents isolate context |
+| State persistence | In conversation | Filesystem (.autobuild/) |
+| Resume capability | Manual | Automatic from state files |
+
+---
+
+## Reference Index - MUST READ When Needed
+
+**References contain detailed templates and patterns. Read BEFORE you need them.**
+
+| When | Reference | What You Get |
+|------|-----------|--------------|
+| **Step 1: Initialize** | [STATE-FILES.md](references/STATE-FILES.md) | State file format, directory structure |
+| **Step 3: Execute phases** | [PHASE-EXECUTION.md](references/PHASE-EXECUTION.md) | Phase ordering, parallel detection, retry logic |
+| **Step 3: Launch sub-agents** | [SUBAGENT-PROMPTS.md](references/SUBAGENT-PROMPTS.md) | Exact prompts for phase sub-agents |
+| **Step 4: Verify and commit** | [VERIFICATION.md](references/VERIFICATION.md) | Fresh verification, commit handling |
+| **Step 5: Handle failures** | [FAILURE-HANDLING.md](references/FAILURE-HANDLING.md) | Retry logic, error recovery |
+| **Overall flow** | [ORCHESTRATION.md](references/ORCHESTRATION.md) | Main orchestration loop, completion handling |
+
+**Also reference superplan/superbuild documents:**
+- `superplan/references/TASK-MICROSTRUCTURE.md` - TDD 5-step format per task
+- `superplan/references/TDD-DISCIPLINE.md` - TDD enforcement rules
+- `superbuild/references/ENFORCEMENT-GUIDE.md` - Quality gate commands by stack, evidence requirements
+- `superbuild/references/PLAN-UPDATES.md` - Plan checkbox patterns, status updates
+
+**DO NOT SKIP REFERENCES.** They contain exact prompts, templates, and formats that are NOT duplicated here.
+
+---
+
+## CLI Arguments
+
+```
+/autobuild <plan-path> [options]
+
+Arguments:
+  plan-path           Path to superplan document (required)
+
+Options:
+  --commit=<mode>     Git commit behavior (required before execution)
+                      - auto: Auto-commit after each phase passes
+                      - message-only: Generate messages, user handles git
+                      - single: One combined commit at the end
+
+  --resume            Resume from existing state (default if .autobuild/ exists)
+  --fresh             Ignore existing state, start from scratch
+  --dry-run           Validate plan and show execution order without running
+```
+
+**Example invocations:**
+```bash
+/autobuild docs/feature-plan.md --commit=auto
+/autobuild docs/feature-plan.md --commit=message-only --resume
+/autobuild docs/feature-plan.md --commit=single --fresh
+```
+
+---
+
+## Critical Workflow
+
+```
++-----------------------------------------------------------------------+
+|                      AUTOBUILD EXECUTION FLOW                          |
++-----------------------------------------------------------------------+
+|                                                                       |
+|  1. INITIALIZE       |  Parse args, create .autobuild/, detect stack  |
+|         |            |  NO PLAN = EXIT (ask user, then exit if none)  |
+|         v            |  NO --commit = STOP (require commit mode)      |
+|  2. LOAD STATE       |  Read existing state files if --resume         |
+|         |            |  Identify completed phases, pending phases     |
+|         v                                                             |
+|  2.5 PLAN REVIEW     |  Validate plan before autonomous execution     |
+|         |            |  Check: ambiguity, deps, tests, risks, conflicts|
+|         v            |  IF concerns → EXIT (autonomous = no recovery) |
+|  3. EXECUTE PHASES   |  For each pending phase (or parallel group):   |
+|     |                |                                                |
+|     |  3a. Launch sub-agent(s) for phase(s)                           |
+|     |      - Sequential phases: one sub-agent at a time               |
+|     |      - Parallel phases (2a,2b,2c): concurrent sub-agents        |
+|     |                                                                 |
+|     |  3b. Sub-agent executes:                                        |
+|     |      - Read plan section for its phase                          |
+|     |      - Follow TDD micro-structure per task                      |
+|     |      - Run quality gates (lint, test, typecheck)                |
+|     |      - Update plan checkboxes                                   |
+|     |      - Return: status, commit message, files changed            |
+|     |                                                                 |
+|     |  3c. Write state file for phase                                 |
+|         |                                                             |
+|         v                                                             |
+|  4. VERIFY + COMMIT  |  Re-run quality gates fresh (trust but verify) |
+|         |            |  Handle git based on --commit mode              |
+|         v                                                             |
+|  5. ON FAILURE       |  Retry once, then halt with state preserved    |
+|         |            |  Parallel siblings may continue before halt    |
+|         v                                                             |
+|  6. COMPLETION       |  All phases done, output summary               |
+|                      |  State files preserved for audit               |
+|                                                                       |
+|  =====================================================================|
+|  Sub-agents are ISOLATED. Context never exhausts. State is on disk.   |
+|  =====================================================================|
+|                                                                       |
++-----------------------------------------------------------------------+
+```
+
+---
+
+## Step 1: Initialize
+
+**REQUIRED: Plan document and commit mode must be provided.**
+
+### Argument Validation
+
+```
+AUTOBUILD INITIALIZATION
+=========================
+
+Plan: [path]
+Commit Mode: [auto|message-only|single]
+
+Validating...
+```
+
+**If no plan provided:**
+```
+ERROR: No plan document provided.
+
+Usage: /autobuild <plan-path> --commit=<mode>
+
+Example: /autobuild docs/feature-plan.md --commit=auto
+
+[EXIT - Cannot proceed without plan]
+```
+
+**If no --commit mode specified:**
+```
+COMMIT MODE REQUIRED
+====================
+
+Before I can execute this plan, I need to know how to handle git commits.
+
+Please specify one of:
+  --commit=auto         Auto-commit after each successful phase
+  --commit=message-only Generate messages, you handle git (recommended)
+  --commit=single       One combined commit after all phases complete
+
+Example: /autobuild docs/feature-plan.md --commit=message-only
+
+[WAITING FOR COMMIT MODE]
+```
+
+**NO EXCEPTIONS.** Do not proceed without explicit commit mode.
+
+### Directory Setup
+
+Create `.autobuild/` directory structure:
+
+```
+.autobuild/
+  config.json           # Execution configuration
+  phases/
+    phase-0.json        # State file per phase
+    phase-1.json
+    phase-2a.json
+    phase-2b.json
+    ...
+  logs/
+    execution.log       # Overall execution log
+    phase-0.log         # Per-phase logs (truncated sub-agent output)
+    ...
+```
+
+> **STOP. Read [STATE-FILES.md](references/STATE-FILES.md) NOW** for complete state file format.
+
+### Stack Detection
+
+Detect technology stack to determine quality commands:
+
+```
+STACK DETECTION
+===============
+
+Detected:
+- Language: TypeScript
+- Framework: Express
+- Package Manager: pnpm
+- Test Framework: Jest
+- Linter: ESLint
+- Formatter: Prettier
+
+Quality Commands:
+- Lint: pnpm run lint
+- Format: pnpm run format:check
+- Typecheck: pnpm run typecheck
+- Test: pnpm test
+
+Stack saved to .autobuild/config.json
+```
+
+---
+
+## Step 2: Load State (Resume Support)
+
+If `.autobuild/` exists and `--resume` (or default):
+
+```
+LOADING EXISTING STATE
+======================
+
+Found existing execution state:
+- Config: .autobuild/config.json
+- Phase files: 6 found
+
+Phase Status:
+| Phase | Name | State File | Status |
+|-------|------|------------|--------|
+| 0 | Bootstrap | phase-0.json | complete |
+| 1 | Setup | phase-1.json | complete |
+| 2A | Backend | phase-2a.json | failed |
+| 2B | Frontend | phase-2b.json | complete |
+| 2C | Tests | phase-2c.json | pending |
+| 3 | Integration | phase-3.json | pending |
+
+Resuming from Phase 2A (first incomplete)...
+```
+
+If `--fresh` specified:
+```
+FRESH START
+===========
+
+--fresh flag detected. Clearing existing state.
+
+Removed: .autobuild/ (6 state files)
+Created: .autobuild/ (fresh)
+
+Starting from Phase 0...
+```
+
+---
+
+## Step 2.5: Critical Plan Review
+
+**Before executing, validate the plan for autonomous execution.**
+
+Unlike interactive superbuild where users can catch issues between phases, autobuild runs autonomously. Plan validation is therefore MORE critical.
+
+### Review Checklist
+
+1. **Ambiguous tasks** - Any task unclear about what to do?
+2. **Missing dependencies** - Are required files/APIs/packages identified?
+3. **Test gaps** - Does each task have testable acceptance criteria?
+4. **Risky changes** - Any destructive operations or breaking changes?
+5. **Parallel conflicts** - Could parallel phases modify the same files?
+
+### If Concerns Exist
+
+```
+⚠️  PLAN REVIEW - Concerns Identified
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+1. [Concern 1 - what and why]
+2. [Concern 2 - what and why]
+
+Autonomous execution requires clear plans.
+Please clarify before I proceed.
+
+[EXECUTION BLOCKED - Plan validation failed]
+```
+
+**For autonomous builds, DO NOT proceed with ambiguous plans.** Exit and request clarification.
+
+### If No Concerns
+
+```
+PLAN VALIDATION: PASSED
+=======================
+
+- Tasks: Clear and actionable
+- Dependencies: Identified
+- Tests: Acceptance criteria present
+- Risks: None detected
+- Parallel safety: No file conflicts expected
+
+Proceeding to execution...
+```
+
+---
+
+## Step 3: Execute Phases
+
+### Phase Ordering
+
+> **STOP. Read [PHASE-EXECUTION.md](references/PHASE-EXECUTION.md) NOW** for phase ordering rules.
+
+Parse plan to build execution order:
+
+1. **Identify all phases** from plan overview table
+2. **Build dependency graph** from "Depends On" column
+3. **Identify parallel groups** from "Parallel With" column
+4. **Topologically sort** for execution order
+
+```
+EXECUTION ORDER
+===============
+
+Batch 1 (sequential): Phase 0
+Batch 2 (sequential): Phase 1
+Batch 3 (parallel): Phase 2A, 2B, 2C
+Batch 4 (sequential): Phase 3
+
+Total: 6 phases in 4 batches
+```
+
+### Launching Sub-Agents
+
+> **STOP. Read [SUBAGENT-PROMPTS.md](references/SUBAGENT-PROMPTS.md) NOW** for exact sub-agent prompts.
+
+#### Sequential Phase
+
+```
+EXECUTING PHASE 1: Setup
+========================
+
+Launching sub-agent...
+
+[Sub-agent executes autonomously]
+[Reads plan section]
+[Follows TDD micro-structure]
+[Runs quality gates]
+[Updates plan checkboxes]
+[Returns result]
+
+Sub-agent complete. Processing result...
+```
+
+#### Parallel Phases
+
+```
+EXECUTING PARALLEL BATCH: 2A, 2B, 2C
+=====================================
+
+Launching 3 sub-agents in parallel...
+
+[Sub-agent 2A: Backend API]
+[Sub-agent 2B: Frontend UI]
+[Sub-agent 2C: Edge Case Tests]
+
+Waiting for all sub-agents to complete...
+
+Results received:
+- Phase 2A: complete
+- Phase 2B: complete
+- Phase 2C: complete
+
+Processing parallel results...
+```
+
+**CRITICAL:** Use Task tool with `run_in_background: true` for parallel phases, then collect results with TaskOutput.
+
+### Sub-Agent Execution
+
+Each sub-agent:
+
+1. **Reads the plan** - Specific section for its phase
+2. **Follows TDD** - 5-step micro-structure per task
+3. **Runs quality gates** - Lint, test, typecheck
+4. **Updates plan file** - Checks off completed tasks
+5. **Returns structured result** - JSON with status, commit, files
+
+Sub-agent does NOT:
+- Run git commands (unless --commit=auto in main agent)
+- Modify other phases
+- Access conversation history from main agent
+
+---
+
+## Step 4: Verify and Commit
+
+### Fresh Verification (Trust But Verify)
+
+> **STOP. Read [VERIFICATION.md](references/VERIFICATION.md) NOW** for verification requirements.
+
+**After sub-agent reports success, VERIFY FRESH in main agent:**
+
+```
+VERIFICATION - Phase 2A
+=======================
+
+Sub-agent reported: complete
+
+Running fresh verification...
+
+Lint:      pnpm run lint           ... PASS
+Format:    pnpm run format:check   ... PASS
+Typecheck: pnpm run typecheck      ... PASS
+Tests:     pnpm test               ... PASS (47 tests)
+
+All quality gates passed.
+```
+
+**If verification fails (sub-agent claimed success but check fails):**
+
+```
+VERIFICATION MISMATCH
+=====================
+
+Sub-agent claimed success, but fresh verification failed:
+
+Tests: FAIL
+  5 tests failed in src/services/auth.test.ts
+
+This indicates a sub-agent error. Treating as phase failure.
+Initiating retry...
+```
+
+### Commit Handling
+
+Based on `--commit` mode:
+
+#### --commit=auto
+```
+AUTO-COMMIT - Phase 2A
+======================
+
+git add src/api/auth.ts src/api/auth.test.ts
+git commit -m "$(cat <<'EOF'
+feat(auth): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+
+Commit created: a1b2c3d
+```
+
+#### --commit=message-only
+```
+COMMIT MESSAGE - Phase 2A
+=========================
+
+feat(auth): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+
+Files to commit:
+- src/api/auth.ts (CREATE)
+- src/api/auth.test.ts (CREATE)
+
+[Message saved to .autobuild/phases/phase-2a.json]
+[User handles git operations]
+```
+
+#### --commit=single
+```
+PHASE 2A COMPLETE
+=================
+
+Commit message queued for final combined commit.
+Continuing to next phase...
+```
+
+### State File Update
+
+After each phase (success or failure), update state file:
+
+```
+STATE UPDATED - Phase 2A
+========================
+
+File: .autobuild/phases/phase-2a.json
+Status: complete
+Commit: feat(auth): implement JWT token validation
+Files: 2 created, 0 modified
+Timestamp: 2025-01-25T10:30:00Z
+```
+
+---
+
+## Step 5: Handle Failures
+
+> **STOP. Read [FAILURE-HANDLING.md](references/FAILURE-HANDLING.md) NOW** for failure handling.
+
+### Retry Logic
+
+On phase failure, retry ONCE:
+
+```
+PHASE FAILURE - Phase 2A (Attempt 1/2)
+======================================
+
+Sub-agent reported failure:
+- Tests failed: 3 failing in auth.test.ts
+- Linter: passed
+- Typecheck: passed
+
+Initiating retry...
+
+RETRY - Phase 2A (Attempt 2/2)
+==============================
+
+Launching fresh sub-agent with error context...
+
+[Sub-agent executes with knowledge of previous failure]
+```
+
+### Parallel Sibling Handling
+
+If a parallel phase fails, let siblings complete:
+
+```
+PARALLEL BATCH FAILURE
+======================
+
+Phase 2A: FAILED (after retry)
+Phase 2B: complete
+Phase 2C: running...
+
+Waiting for 2C to complete before halting...
+
+Phase 2C: complete
+
+EXECUTION HALTED
+================
+
+Phase 2A failed after retry.
+Siblings 2B and 2C completed successfully.
+
+State preserved in .autobuild/
+Resume with: /autobuild docs/feature-plan.md --commit=auto --resume
+```
+
+### Halt State
+
+```
+AUTOBUILD HALTED
+================
+
+Execution stopped due to: Phase 2A failure (tests failing)
+
+Completed phases:
+- Phase 0: Bootstrap (complete)
+- Phase 1: Setup (complete)
+- Phase 2B: Frontend (complete)
+- Phase 2C: Tests (complete)
+
+Failed phase:
+- Phase 2A: Backend (failed after retry)
+
+Remaining phases:
+- Phase 3: Integration (blocked by 2A)
+
+State preserved: .autobuild/
+
+To resume after fixing:
+  /autobuild docs/feature-plan.md --commit=auto --resume
+
+To start fresh:
+  /autobuild docs/feature-plan.md --commit=auto --fresh
+```
+
+---
+
+## Step 6: Completion
+
+When all phases complete:
+
+```
++=====================================================================+
+|                     AUTOBUILD COMPLETE                               |
++=====================================================================+
+
+Plan: docs/feature-plan.md
+Duration: [calculated from timestamps]
+Phases: 6/6 complete
+
+Phase Summary:
+| Phase | Name | Status | Commit |
+|-------|------|--------|--------|
+| 0 | Bootstrap | complete | chore(bootstrap): add quality tools |
+| 1 | Setup | complete | feat(db): add user schema |
+| 2A | Backend | complete | feat(api): implement auth endpoints |
+| 2B | Frontend | complete | feat(ui): add login form |
+| 2C | Tests | complete | test(auth): add edge case coverage |
+| 3 | Integration | complete | feat(auth): wire frontend to backend |
+
+Files Changed: [total count]
+Tests Added: [count from test output]
+Coverage: [if available]
+
+State preserved: .autobuild/
+
+[Based on --commit mode, output final instructions]
+```
+
+### --commit=auto completion
+```
+All commits created successfully.
+Review with: git log --oneline -6
+```
+
+### --commit=message-only completion
+```
+PENDING COMMITS
+===============
+
+The following commits are ready to create:
+
+1. chore(bootstrap): add quality tools
+   git add ... && git commit -m "..."
+
+2. feat(db): add user schema
+   git add ... && git commit -m "..."
+
+[etc.]
+
+Full commit commands saved to: .autobuild/commits.sh
+Run with: bash .autobuild/commits.sh
+```
+
+### --commit=single completion
+```
+COMBINED COMMIT MESSAGE
+=======================
+
+feat(auth): implement complete authentication system
+
+This commit includes:
+- Bootstrap: quality tools configuration
+- Database: user schema and migrations
+- API: authentication endpoints with JWT
+- UI: login and registration forms
+- Tests: comprehensive test coverage
+- Integration: full e2e authentication flow
+
+Phases completed: 6
+Files changed: [count]
+```
+
+---
+
+## Definition of Done Verification (CRITICAL)
+
+**Quality gates alone are insufficient.** Tests passing does NOT mean the phase is complete.
+
+### The Integration Trap
+
+A common failure mode is:
+1. Code is written (function exists)
+2. Tests pass (function works when called)
+3. BUT the code is never wired up (function never gets called)
+4. Phase marked "complete" when it's actually broken
+
+**Example:** `LoadDiscoveries()` created, tests pass, but it's never called from `Init()`. The Discovered section shows nothing. Tests pass because no test verified the integration.
+
+### Mandatory DoD Verification
+
+After quality gates pass, the sub-agent MUST verify each Definition of Done item by **actually testing the user-facing behavior**:
+
+```
+DEFINITION OF DONE VERIFICATION
+===============================
+
+DoD: "DISCOVERED SKILLS section displays discoveries"
+
+Verification approach:
+1. Check if LoadDiscoveries() is called (not just defined)
+2. Check if result handler exists in app.go
+3. Trace the data flow: scan → DB → load → display
+
+Result: FAIL - LoadDiscoveries() exists but is never called
+
+Action: Wire up the integration before claiming phase complete
+```
+
+### No TODOs, No Incomplete Wiring
+
+**Leaving TODOs = phase FAILED.** Do not mark a phase complete if:
+- Functions exist but aren't called
+- Handlers exist but aren't wired up
+- Code has `// TODO` comments for core functionality
+- A feature "works in isolation" but isn't integrated
+
+### Verify User-Facing Behavior
+
+For each DoD item, ask: "If a user tried this right now, would it work?"
+
+- "Button displays" → Would the button actually appear?
+- "Data loads" → Would calling the entry point actually load data?
+- "Feature works" → End-to-end, not just unit test passing
+
+**If you can't demonstrate the behavior works end-to-end, the phase is not complete.**
+
+---
+
+## Rationalizations to Reject
+
+| Excuse | Reality |
+|--------|---------|
+| "Let me run multiple phases in one sub-agent" | **NO.** Each phase gets its own sub-agent for context isolation |
+| "I'll skip the state file for this phase" | **NO.** State files enable resume and audit |
+| "The sub-agent passed, no need to verify" | **NO.** Fresh verification is mandatory |
+| "Let me just continue after failure" | **NO.** Retry once, then halt |
+| "Sequential phases can run in parallel" | **NO.** Respect dependency order |
+| "I'll batch the verification at the end" | **NO.** Verify after each phase |
+| "The plan doesn't specify commit mode" | **NO.** Require --commit before execution |
+| "Let me auto-commit without being told" | **NO.** Explicit commit mode required |
+| "Tests pass so the feature works" | **NO.** Verify user-facing behavior, not just unit tests |
+| "The function exists, I'll wire it up later" | **NO.** Unwired code = incomplete phase |
+| "I added a TODO for the next phase" | **NO.** TODOs for core functionality = phase FAILED |
+
+---
+
+## Red Flags - STOP Immediately
+
+If you catch yourself thinking any of these, STOP:
+
+- "Context is getting long, let me combine phases"
+- "This phase is simple, I can skip the sub-agent"
+- "The retry failed, but let me try once more"
+- "Sequential phases don't really depend on each other"
+- "I'll write the state files at the end"
+- "Verification is redundant, sub-agents are reliable"
+- "The user probably wants auto-commit"
+- "Tests pass so the DoD is met"
+- "The code exists, even if it's not called yet"
+- "I'll add a TODO and the next phase will handle it"
+- "This function works, I just need to wire it up"
+- "The implementation is there, integration is trivial"
+
+**All of these = violation of autobuild protocol.**
+
+---
+
+## The Iron Rules
+
+1. **Explicit commit mode** - Never start without --commit flag
+2. **One sub-agent per phase** - Context isolation is non-negotiable
+3. **State file per phase** - Written immediately after completion/failure
+4. **Fresh verification** - Never trust sub-agent claims alone
+5. **Single retry on failure** - Then halt with state preserved
+6. **Respect dependencies** - Sequential means sequential
+7. **Parallel means parallel** - Launch concurrent sub-agents
+8. **Resume from state** - Check .autobuild/ before starting
+9. **Preserve state on halt** - Enable future resume
+10. **No user intervention** - Fully autonomous execution
+11. **DoD means user-facing behavior works** - Not just "code exists" or "tests pass"
+12. **No TODOs for core functionality** - Complete the phase or mark it failed
+13. **Integration is part of implementation** - Unwired code is incomplete code
+
+**Autobuild is rigid by design.** The sub-agent isolation prevents context exhaustion. The state files enable resume. The verification ensures quality. Do not rationalize around it.

--- a/.codex/skills/autobuild/references/FAILURE-HANDLING.md
+++ b/.codex/skills/autobuild/references/FAILURE-HANDLING.md
@@ -1,0 +1,569 @@
+# Failure Handling Reference
+
+> Retry logic, error recovery, parallel sibling handling, and halt procedures.
+
+## Failure Classification
+
+| Failure Type | Retryable | Description |
+|--------------|-----------|-------------|
+| `test_failure` | Yes | Tests failed, code may need fixes |
+| `lint_error` | Yes | Linting errors, auto-fixable or manual |
+| `typecheck_error` | Yes | Type errors in implementation |
+| `format_error` | Yes | Usually auto-fixable |
+| `task_incomplete` | Yes | Sub-agent didn't finish all tasks |
+| `verification_mismatch` | Yes | Claimed success but verification failed |
+| `timeout` | Yes | Sub-agent took too long |
+| `parse_error` | Yes | Couldn't parse sub-agent result |
+| `dependency_missing` | No | Required package/tool not installed |
+| `circular_dependency` | No | Plan has circular phase dependencies |
+| `file_conflict` | No | Parallel phases modified same file |
+| `plan_invalid` | No | Plan format is incorrect |
+
+---
+
+## Retry Logic
+
+### Single Retry Strategy
+
+Each phase gets exactly ONE retry before failure:
+
+```
+PHASE FAILURE HANDLING
+======================
+
+Attempt 1: Execute phase normally
+            |
+            v
+        Failed?
+       /       \
+      No        Yes
+      |          |
+   Success    Attempt 2: Execute with error context
+                   |
+                   v
+               Failed?
+              /       \
+             No        Yes
+             |          |
+          Success    HALT
+```
+
+### Why Single Retry?
+
+1. **Efficiency** - Multiple retries waste time on unfixable issues
+2. **Signal** - Two failures strongly suggest manual intervention needed
+3. **Determinism** - Predictable behavior, not indefinite loops
+4. **Context** - Retry includes error context for better chance of success
+
+---
+
+## Retry Execution
+
+### Initiating Retry
+
+```
+PHASE FAILURE - Initiating Retry
+================================
+
+Phase: 2A (Backend API)
+Attempt: 1 of 2
+
+Failure details:
+  Type: test_failure
+  Message: 3 tests failing in auth.test.ts
+  Tests: validateToken, refreshToken, handleExpired
+
+Launching retry sub-agent with error context...
+
+[See SUBAGENT-PROMPTS.md for retry prompt template]
+```
+
+### Error Context for Retry
+
+Pass previous failure information to retry sub-agent:
+
+```python
+def build_retry_context(phase_state):
+    return {
+        "previous_error_type": phase_state["error"]["type"],
+        "previous_error_message": phase_state["error"]["message"],
+        "previous_error_details": phase_state["error"].get("details", ""),
+        "tasks_completed": phase_state["execution"]["tasks_completed"],
+        "tasks_total": phase_state["execution"]["tasks_total"],
+        "retry_guidance": get_retry_guidance(phase_state["error"]["type"])
+    }
+```
+
+### Retry State Update
+
+Before retry:
+```json
+{
+  "phase_id": "2a",
+  "status": "running",
+  "attempt": 2,
+  "max_attempts": 2,
+  "error": {
+    "attempt_1": {
+      "type": "test_failure",
+      "message": "3 tests failing"
+    }
+  }
+}
+```
+
+After retry success:
+```json
+{
+  "phase_id": "2a",
+  "status": "complete",
+  "attempt": 2,
+  "error": {
+    "attempt_1": {
+      "type": "test_failure",
+      "message": "3 tests failing"
+    },
+    "resolved_on_retry": true
+  }
+}
+```
+
+After retry failure:
+```json
+{
+  "phase_id": "2a",
+  "status": "failed",
+  "attempt": 2,
+  "error": {
+    "attempt_1": {
+      "type": "test_failure",
+      "message": "3 tests failing"
+    },
+    "attempt_2": {
+      "type": "test_failure",
+      "message": "3 tests still failing"
+    },
+    "final": "Failed after maximum retries"
+  }
+}
+```
+
+---
+
+## Parallel Sibling Handling
+
+When a phase in a parallel batch fails:
+
+### Let Siblings Complete
+
+```
+PARALLEL BATCH - PARTIAL FAILURE
+================================
+
+Batch: [2A, 2B, 2C]
+
+Status:
+  Phase 2A: FAILED (attempt 1)
+  Phase 2B: running...
+  Phase 2C: complete
+
+Decision: Allow running siblings to complete before retry.
+
+Rationale:
+1. Siblings may succeed, preserving their work
+2. Retry of 2A won't conflict with running 2B
+3. More efficient than cancelling all
+
+Waiting for 2B to complete...
+```
+
+### Sibling Completion Then Retry
+
+```
+PARALLEL BATCH - RETRY AFTER SIBLINGS
+=====================================
+
+All siblings complete:
+  Phase 2A: failed (attempt 1)
+  Phase 2B: complete
+  Phase 2C: complete
+
+Initiating retry for Phase 2A...
+
+Note: 2B and 2C results preserved. Their commits (if --commit=auto)
+already created. 2A retry runs in isolation.
+```
+
+### Multiple Siblings Fail
+
+```
+PARALLEL BATCH - MULTIPLE FAILURES
+==================================
+
+Batch: [2A, 2B, 2C]
+
+Results:
+  Phase 2A: failed
+  Phase 2B: failed
+  Phase 2C: complete
+
+Multiple phases failed. Retrying each:
+
+Retry 1: Phase 2A (parallel with 2B retry)
+Retry 2: Phase 2B (parallel with 2A retry)
+
+[Retries run in parallel since they're independent]
+
+Retry results:
+  Phase 2A: complete (retry succeeded)
+  Phase 2B: failed (retry failed)
+
+Phase 2B failed after retry.
+AUTOBUILD HALTED
+```
+
+---
+
+## Halt Procedure
+
+When halt is triggered:
+
+### Halt Sequence
+
+```
+AUTOBUILD HALT SEQUENCE
+=======================
+
+1. Stop launching new phases
+2. Wait for running phases to complete (or timeout)
+3. Write final state files
+4. Update execution log
+5. Output halt summary
+6. Preserve state for resume
+```
+
+### Halt Summary Output
+
+```
+╔═══════════════════════════════════════════════════════════════════╗
+║                       AUTOBUILD HALTED                             ║
+╠═══════════════════════════════════════════════════════════════════╣
+║                                                                   ║
+║  Reason: Phase 2A failed after retry                              ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  COMPLETED PHASES                                                 ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Phase 0: Bootstrap .......................... complete           ║
+║    Commit: chore(bootstrap): add quality tools                    ║
+║                                                                   ║
+║  Phase 1: Setup .............................. complete           ║
+║    Commit: feat(db): add user schema                              ║
+║                                                                   ║
+║  Phase 2B: Frontend .......................... complete           ║
+║    Commit: feat(ui): add login form                               ║
+║                                                                   ║
+║  Phase 2C: Tests ............................. complete           ║
+║    Commit: test(auth): add edge cases                             ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  FAILED PHASE                                                     ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Phase 2A: Backend ........................... FAILED             ║
+║    Attempts: 2/2                                                  ║
+║    Error: test_failure                                            ║
+║    Details: 3 tests failing - validateToken returns null          ║
+║             instead of user object                                ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  BLOCKED PHASES                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Phase 3: Integration ........................ blocked            ║
+║    Blocked by: 2A                                                 ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  STATE PRESERVED                                                  ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  Directory: .autobuild/                                           ║
+║  State files: 6 phases                                            ║
+║  Logs: .autobuild/logs/                                           ║
+║                                                                   ║
+║  ─────────────────────────────────────────────────────────────   ║
+║  RESUME INSTRUCTIONS                                              ║
+║  ─────────────────────────────────────────────────────────────   ║
+║                                                                   ║
+║  1. Fix the failing tests in src/api/auth.test.ts                 ║
+║  2. Run: /autobuild docs/feature-plan.md --commit=auto --resume   ║
+║                                                                   ║
+║  To start fresh: Add --fresh flag                                 ║
+║                                                                   ║
+╚═══════════════════════════════════════════════════════════════════╝
+```
+
+---
+
+## Error Type Handling
+
+### test_failure
+
+```
+ERROR: test_failure
+==================
+
+Symptoms:
+- Test command exited with non-zero
+- One or more test cases failed
+
+Information to capture:
+- Number of tests failed
+- Test file paths
+- Test names
+- Error messages
+
+Retry guidance:
+"Fix the failing tests. The errors are in {FILES}.
+Common issues: incorrect assertions, missing mocks, async timing."
+
+User action if retry fails:
+- Review test failures manually
+- Check if tests are flaky
+- Verify test assumptions match implementation
+```
+
+### lint_error
+
+```
+ERROR: lint_error
+=================
+
+Symptoms:
+- Linter exited with non-zero
+- Linting rules violated
+
+Information to capture:
+- Number of errors
+- File paths with errors
+- Rule names violated
+- Line numbers
+
+Retry guidance:
+"Fix linting errors. Run `{LINT_COMMAND}` to see current errors.
+Most are auto-fixable with `{LINT_FIX_COMMAND}`."
+
+User action if retry fails:
+- Review lint rules
+- Consider disabling problematic rules
+- Check for conflicting lint configurations
+```
+
+### typecheck_error
+
+```
+ERROR: typecheck_error
+======================
+
+Symptoms:
+- Type checker exited with non-zero
+- Type mismatches or missing types
+
+Information to capture:
+- Number of errors
+- File paths with errors
+- Error messages (type expected vs actual)
+- Line numbers
+
+Retry guidance:
+"Fix type errors. Run `{TYPECHECK_COMMAND}` to see current errors.
+Check that function signatures match usage."
+
+User action if retry fails:
+- Review type definitions
+- Check for missing @types packages
+- Verify tsconfig/mypy configuration
+```
+
+### timeout
+
+```
+ERROR: timeout
+==============
+
+Symptoms:
+- Sub-agent didn't respond within time limit
+- May have been stuck on a task
+
+Information to capture:
+- How long before timeout
+- Last known activity (if any)
+
+Retry guidance:
+"Previous attempt timed out. Focus on completing tasks efficiently.
+If tests are slow, consider running targeted tests only."
+
+User action if retry fails:
+- Increase timeout (if justified)
+- Break phase into smaller phases
+- Check for infinite loops or hanging operations
+```
+
+### verification_mismatch
+
+```
+ERROR: verification_mismatch
+============================
+
+Symptoms:
+- Sub-agent claimed success
+- Fresh verification in main agent failed
+
+Information to capture:
+- What sub-agent claimed
+- What fresh verification found
+- Discrepancy details
+
+Retry guidance:
+"Previous sub-agent reported success but verification failed.
+Run ALL quality gates after EVERY change. Ensure tests pass
+at the end, not just during development."
+
+User action if retry fails:
+- Review sub-agent logs
+- Check for race conditions
+- Verify no external state changes
+```
+
+---
+
+## Non-Retryable Errors
+
+### dependency_missing
+
+```
+ERROR: dependency_missing (NON-RETRYABLE)
+=========================================
+
+Required dependency not installed:
+  Package: @types/jest
+  Required by: Type checking
+
+AUTOBUILD CANNOT PROCEED
+
+Resolution:
+  Install missing dependency: npm install -D @types/jest
+  Then resume: /autobuild docs/feature-plan.md --commit=auto --resume
+
+[HALTED - Manual intervention required]
+```
+
+### circular_dependency
+
+```
+ERROR: circular_dependency (NON-RETRYABLE)
+==========================================
+
+Plan contains circular phase dependencies:
+  Phase 2A depends on Phase 3
+  Phase 3 depends on Phase 2A
+
+AUTOBUILD CANNOT PROCEED
+
+Resolution:
+  Fix the plan's "Depends On" column to remove the cycle.
+  Ensure dependencies form a directed acyclic graph (DAG).
+
+[HALTED - Invalid plan]
+```
+
+### file_conflict
+
+```
+ERROR: file_conflict (NON-RETRYABLE)
+====================================
+
+Parallel phases modified the same file:
+  File: src/api/routes.ts
+  Phase 2A modified lines 10-25
+  Phase 2B modified lines 15-30
+
+AUTOBUILD CANNOT PROCEED
+
+Resolution options:
+1. Manually merge the changes
+2. Modify plan to make these phases sequential
+3. Split the shared file to avoid conflicts
+
+[HALTED - Parallel conflict]
+```
+
+---
+
+## Recovery Scenarios
+
+### Resume After Fix
+
+User fixes the issue externally, then resumes:
+
+```
+RESUME AFTER EXTERNAL FIX
+=========================
+
+Previous state:
+  Phase 2A: failed (test_failure)
+
+User action: Fixed tests in src/api/auth.test.ts
+
+Resume command: /autobuild docs/feature-plan.md --commit=auto --resume
+
+Resume behavior:
+1. Read state files
+2. Find Phase 2A in failed status
+3. Reset attempt count to 0
+4. Re-execute Phase 2A
+5. Continue with remaining phases if successful
+```
+
+### Fresh Start After Corruption
+
+If state files are corrupted or need reset:
+
+```
+FRESH START
+===========
+
+User command: /autobuild docs/feature-plan.md --commit=auto --fresh
+
+Behavior:
+1. Delete .autobuild/ directory
+2. Create fresh state files
+3. Start from Phase 0
+4. All previous commits remain (if --commit=auto was used)
+
+Warning: Does not undo previous commits. Use git reset if needed.
+```
+
+### Partial Recovery
+
+User wants to keep some completed work:
+
+```
+PARTIAL RECOVERY
+================
+
+Scenario: Phases 0-2B complete, 2C and later need re-run
+
+Option 1: Edit state files manually
+  - Set phase-2c.json status to "pending"
+  - Delete phase-3.json (or set to "pending")
+  - Run with --resume
+
+Option 2: Use fresh and re-commit
+  - Run with --fresh
+  - All phases re-execute
+  - Creates duplicate commits (may need squash)
+
+Recommendation: Option 1 for surgical recovery
+```

--- a/.codex/skills/autobuild/references/ORCHESTRATION.md
+++ b/.codex/skills/autobuild/references/ORCHESTRATION.md
@@ -1,0 +1,592 @@
+# Orchestration Reference
+
+> Main execution loop, phase coordination, and completion handling.
+
+## Orchestration Overview
+
+The main agent orchestrates execution without accumulating context:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    ORCHESTRATION RESPONSIBILITIES                    │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  Main Agent (Orchestrator):                                         │
+│  ├── Parse arguments and validate                                   │
+│  ├── Initialize .autobuild/ directory                               │
+│  ├── Detect technology stack                                        │
+│  ├── Parse plan and build execution order                           │
+│  ├── Load existing state (if --resume)                              │
+│  ├── Launch sub-agents for each phase                               │
+│  ├── Verify sub-agent results                                       │
+│  ├── Handle commits based on --commit mode                          │
+│  ├── Handle failures and retries                                    │
+│  └── Output completion or halt summary                              │
+│                                                                     │
+│  Sub-Agents (Executors):                                            │
+│  ├── Read their phase section from plan                             │
+│  ├── Execute tasks following TDD                                    │
+│  ├── Run quality gates                                              │
+│  ├── Update plan file                                               │
+│  └── Return structured result JSON                                  │
+│                                                                     │
+│  Filesystem (State):                                                │
+│  ├── .autobuild/config.json - execution config                      │
+│  ├── .autobuild/phases/*.json - phase state files                   │
+│  └── .autobuild/logs/*.log - execution logs                         │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Main Execution Loop
+
+### Pseudocode
+
+```python
+def autobuild_main(plan_path, commit_mode, resume, fresh):
+    # Step 1: Initialize
+    validate_arguments(plan_path, commit_mode)
+    if fresh:
+        delete_autobuild_dir()
+    create_autobuild_dir()
+    config = detect_stack_and_commands()
+    save_config(config)
+
+    # Step 2: Parse plan
+    plan = read_plan(plan_path)
+    phases = parse_phases(plan)
+    batches = create_execution_batches(phases)
+
+    # Step 3: Load state (if resume)
+    if resume and state_exists():
+        states = load_phase_states()
+        resume_point = find_resume_point(states, batches)
+    else:
+        states = create_initial_states(phases)
+        resume_point = batches[0]
+
+    # Step 4: Execute batches
+    for batch in batches:
+        if batch_before(batch, resume_point):
+            continue  # Already complete
+
+        if batch["type"] == "sequential":
+            result = execute_sequential_batch(batch, config, states)
+        else:
+            result = execute_parallel_batch(batch, config, states)
+
+        if result["status"] == "failed":
+            output_halt_summary(states, result["failed_phase"])
+            return
+
+    # Step 5: Completion
+    output_completion_summary(states, commit_mode)
+```
+
+### Batch Execution Functions
+
+```python
+def execute_sequential_batch(batch, config, states):
+    for phase_id in batch["phases"]:
+        result = execute_phase(phase_id, config, states)
+
+        if result["status"] == "failed":
+            # Try retry
+            retry_result = retry_phase(phase_id, config, states, result["error"])
+
+            if retry_result["status"] == "failed":
+                return {"status": "failed", "failed_phase": phase_id}
+
+    return {"status": "complete"}
+
+
+def execute_parallel_batch(batch, config, states):
+    # Launch all phases in parallel
+    tasks = {}
+    for phase_id in batch["phases"]:
+        task_id = launch_phase_background(phase_id, config)
+        tasks[phase_id] = task_id
+
+    # Wait for all to complete
+    results = {}
+    for phase_id, task_id in tasks.items():
+        results[phase_id] = wait_for_task(task_id)
+
+    # Check for failures
+    failed = [p for p, r in results.items() if r["status"] == "failed"]
+
+    if failed:
+        # Retry failed phases (can also be parallel)
+        retry_results = retry_phases_parallel(failed, config, states, results)
+
+        still_failed = [p for p, r in retry_results.items() if r["status"] == "failed"]
+
+        if still_failed:
+            return {"status": "failed", "failed_phase": still_failed[0]}
+
+    return {"status": "complete"}
+```
+
+---
+
+## Phase Execution Flow
+
+### Single Phase Execution
+
+```
+PHASE EXECUTION: {PHASE_ID}
+===========================
+
+1. CREATE/UPDATE state file
+   Status: running
+   Attempt: {N}
+
+2. LAUNCH sub-agent
+   [See SUBAGENT-PROMPTS.md]
+
+3. WAIT for sub-agent completion
+   Timeout: 10 minutes
+
+4. PARSE sub-agent result
+   Extract JSON from output
+
+5. VERIFY results
+   Run fresh quality gates
+   Check files exist
+   Check plan updated
+
+6. IF verification passes:
+   - Update state: complete
+   - Handle commit
+   - Log success
+
+7. IF verification fails:
+   - Update state: error details
+   - Return failure for retry handling
+```
+
+### State File Updates During Execution
+
+```python
+def execute_phase(phase_id, config, states):
+    # Mark as running
+    update_state(phase_id, {
+        "status": "running",
+        "attempt": states[phase_id]["attempt"] + 1,
+        "timestamps": {"started": now()}
+    })
+
+    # Launch sub-agent
+    result = launch_subagent(phase_id, config)
+
+    # Verify
+    verification = verify_result(result, config)
+
+    if verification["passed"]:
+        update_state(phase_id, {
+            "status": "complete",
+            "timestamps": {"completed": now()},
+            "quality_gates": verification["gates"],
+            "commit": result["commit_message"],
+            "files": result["files"]
+        })
+        return {"status": "complete", "result": result}
+    else:
+        update_state(phase_id, {
+            "error": {
+                f"attempt_{states[phase_id]['attempt'] + 1}": {
+                    "type": verification["error_type"],
+                    "message": verification["error_message"]
+                }
+            }
+        })
+        return {"status": "failed", "error": verification}
+```
+
+---
+
+## Parallel Execution Coordination
+
+### Launching Parallel Sub-Agents
+
+```
+PARALLEL LAUNCH: [2A, 2B, 2C]
+=============================
+
+1. For each phase in batch:
+   - Create state file (status: running)
+   - Launch Task with run_in_background: true
+   - Store task ID
+
+2. All tasks launched
+   Task 2A: task-abc-123
+   Task 2B: task-def-456
+   Task 2C: task-ghi-789
+
+3. Wait for completion
+   Using TaskOutput with block: true
+   Timeout: 15 minutes per task
+
+4. Collect results as they complete
+   2C complete: 5m 45s
+   2B complete: 8m 30s
+   2A complete: 10m 15s
+```
+
+### Parallel Task Tool Calls
+
+Launch all parallel phases in a SINGLE message with multiple Task tool calls:
+
+```
+[Message with 3 Task tool calls]
+
+Task 1:
+  description: "Execute Phase 2A"
+  prompt: [2A prompt]
+  subagent_type: "general-purpose"
+  run_in_background: true
+
+Task 2:
+  description: "Execute Phase 2B"
+  prompt: [2B prompt]
+  subagent_type: "general-purpose"
+  run_in_background: true
+
+Task 3:
+  description: "Execute Phase 2C"
+  prompt: [2C prompt]
+  subagent_type: "general-purpose"
+  run_in_background: true
+```
+
+### Collecting Parallel Results
+
+```python
+def collect_parallel_results(task_ids, timeout_per_task=600000):
+    results = {}
+
+    for phase_id, task_id in task_ids.items():
+        output = TaskOutput(
+            task_id=task_id,
+            block=True,
+            timeout=timeout_per_task
+        )
+        results[phase_id] = parse_subagent_result(output)
+
+    return results
+```
+
+---
+
+## Commit Orchestration
+
+### --commit=auto Flow
+
+```
+COMMIT ORCHESTRATION (auto)
+===========================
+
+After each phase verification passes:
+
+1. Stage files
+   git add {files_created} {files_modified}
+
+2. Create commit
+   git commit -m "{commit_message}"
+
+3. Capture commit SHA
+   sha = git rev-parse HEAD
+
+4. Update state file
+   commit.committed = true
+   commit.commit_sha = sha
+
+5. Continue to next phase
+```
+
+### --commit=message-only Flow
+
+```
+COMMIT ORCHESTRATION (message-only)
+===================================
+
+After each phase verification passes:
+
+1. Save commit message to state file
+   .autobuild/phases/phase-{id}.json
+
+2. Append to commits script
+   .autobuild/commits.sh
+
+3. Do NOT run git commands
+
+4. Continue to next phase
+
+At completion:
+  Output list of pending commits
+  Point user to commits.sh
+```
+
+### --commit=single Flow
+
+```
+COMMIT ORCHESTRATION (single)
+=============================
+
+After each phase verification passes:
+
+1. Save commit message to state file
+   Mark as "queued for combined commit"
+
+2. Do NOT run git commands
+
+3. Continue to next phase
+
+At completion:
+  Combine all commit messages
+  Create single combined commit message
+  Optionally stage and commit all files
+```
+
+---
+
+## Completion Handling
+
+### All Phases Successful
+
+```python
+def output_completion_summary(states, commit_mode):
+    completed = [s for s in states.values() if s["status"] == "complete"]
+    total_files = sum(len(s["files"]["created"]) + len(s["files"]["modified"])
+                      for s in completed)
+
+    print("""
+╔═══════════════════════════════════════════════════════════════════╗
+║                     AUTOBUILD COMPLETE                             ║
+╠═══════════════════════════════════════════════════════════════════╣
+""")
+
+    # Phase summary table
+    for state in completed:
+        print(f"║  Phase {state['phase_id']}: {state['phase_name']} ... complete")
+        print(f"║    Commit: {state['commit']['message'].split(chr(10))[0]}")
+
+    print(f"""
+║  ─────────────────────────────────────────────────────────────
+║  Total phases: {len(completed)}
+║  Total files changed: {total_files}
+║  State preserved: .autobuild/
+╚═══════════════════════════════════════════════════════════════════╝
+""")
+
+    # Commit mode specific instructions
+    if commit_mode == "auto":
+        print("All commits created. Review with: git log --oneline")
+    elif commit_mode == "message-only":
+        print("Commits ready. Run: bash .autobuild/commits.sh")
+    elif commit_mode == "single":
+        output_combined_commit(states)
+```
+
+### Creating commits.sh
+
+```python
+def create_commits_script(states):
+    script = """#!/bin/bash
+# Generated by autobuild
+# Run with: bash .autobuild/commits.sh
+
+set -e
+
+"""
+    for state in sorted(states.values(), key=lambda s: s["timestamps"]["completed"]):
+        if state["status"] != "complete":
+            continue
+
+        files = state["files"]["created"] + state["files"]["modified"]
+        files_str = " ".join(f'"{f}"' for f in files)
+        message = state["commit"]["message"]
+
+        script += f'''
+echo "Committing Phase {state['phase_id']}: {state['phase_name']}..."
+git add {files_str}
+git commit -m "$(cat <<'EOF'
+{message}
+EOF
+)"
+
+'''
+
+    script += 'echo "All commits complete!"\n'
+
+    write_file(".autobuild/commits.sh", script)
+    Bash(command="chmod +x .autobuild/commits.sh")
+```
+
+---
+
+## Logging
+
+### Execution Log Entries
+
+```python
+def log_event(event_type, message, details=None):
+    timestamp = datetime.now().isoformat()
+    entry = f"[{timestamp}] {event_type}: {message}"
+    if details:
+        entry += f"\n  Details: {details}"
+
+    append_file(".autobuild/logs/execution.log", entry + "\n")
+```
+
+### Log Event Types
+
+| Event | Example |
+|-------|---------|
+| `START` | `AUTOBUILD STARTED - plan: docs/feature-plan.md` |
+| `CONFIG` | `Stack detected: typescript/express` |
+| `BATCH` | `Executing batch 3 (parallel): [2A, 2B, 2C]` |
+| `PHASE_START` | `Phase 2A started (attempt 1)` |
+| `PHASE_COMPLETE` | `Phase 2A complete - feat(api): add auth endpoints` |
+| `PHASE_FAIL` | `Phase 2A failed - test_failure: 3 tests failing` |
+| `RETRY` | `Phase 2A retry initiated (attempt 2)` |
+| `VERIFY` | `Verification passed for Phase 2A` |
+| `COMMIT` | `Commit created: a1b2c3d` |
+| `HALT` | `AUTOBUILD HALTED - Phase 2A failed after retry` |
+| `COMPLETE` | `AUTOBUILD COMPLETE - 6 phases, 24 files` |
+
+### Phase Log Files
+
+Each phase gets a truncated log of its sub-agent execution:
+
+```python
+def save_phase_log(phase_id, subagent_output):
+    # Truncate to reasonable size
+    max_lines = 500
+    lines = subagent_output.split("\n")
+    if len(lines) > max_lines:
+        truncated = lines[:max_lines//2] + ["...[truncated]..."] + lines[-max_lines//2:]
+        output = "\n".join(truncated)
+    else:
+        output = subagent_output
+
+    log_content = f"""=== PHASE {phase_id} SUB-AGENT LOG ===
+Started: {now()}
+
+{output}
+
+=== END PHASE {phase_id} LOG ===
+"""
+
+    write_file(f".autobuild/logs/phase-{phase_id}.log", log_content)
+```
+
+---
+
+## Error Recovery
+
+### Graceful Shutdown
+
+If interrupted (Ctrl+C or system shutdown):
+
+```
+GRACEFUL SHUTDOWN
+=================
+
+Interrupt detected.
+
+Actions:
+1. Signal running sub-agents to stop (if possible)
+2. Update state files with current status
+3. Mark interrupted phases as "running" (will resume)
+4. Save execution log
+
+State preserved. Resume with --resume flag.
+```
+
+### State Corruption Detection
+
+```python
+def validate_state_consistency():
+    config = load_config()
+    states = load_all_states()
+
+    issues = []
+
+    # Check all expected phases have state files
+    for phase_id in config["phases"]:
+        if phase_id not in states:
+            issues.append(f"Missing state file for phase {phase_id}")
+
+    # Check no phase claims complete without commit
+    for state in states.values():
+        if state["status"] == "complete" and not state["commit"]:
+            issues.append(f"Phase {state['phase_id']} complete but no commit")
+
+    # Check dependency consistency
+    for state in states.values():
+        if state["status"] == "complete":
+            for dep in state["dependencies"]["depends_on"]:
+                if states[dep]["status"] != "complete":
+                    issues.append(f"Phase {state['phase_id']} complete but dependency {dep} not complete")
+
+    return issues
+```
+
+### Recovery from Corruption
+
+```
+STATE VALIDATION FAILED
+=======================
+
+Issues detected:
+1. Phase 2a complete but dependency 1 not complete
+2. Missing state file for phase 2c
+
+Options:
+1. Attempt automatic repair
+2. Start fresh with --fresh
+3. Manual state file editing
+
+Recommendation: Start fresh to ensure consistency.
+
+Command: /autobuild docs/feature-plan.md --commit=auto --fresh
+```
+
+---
+
+## Progress Tracking
+
+### Progress Output During Execution
+
+```
+AUTOBUILD PROGRESS
+==================
+
+Plan: docs/feature-plan.md
+Mode: --commit=auto
+
+[■■■■■■■■■■░░░░░░░░░░] 50% (3/6 phases)
+
+Completed:
+  ✓ Phase 0: Bootstrap (2m 15s)
+  ✓ Phase 1: Setup (3m 45s)
+  ✓ Phase 2C: Tests (5m 30s)
+
+In Progress:
+  ⟳ Phase 2A: Backend (running for 4m 20s)
+  ⟳ Phase 2B: Frontend (running for 4m 20s)
+
+Pending:
+  ○ Phase 3: Integration
+
+Estimated remaining: ~15 minutes
+```
+
+### Progress Update Frequency
+
+- Update after each phase completes
+- Update every 60 seconds during long phases
+- Immediate update on failure or halt

--- a/.codex/skills/autobuild/references/PHASE-EXECUTION.md
+++ b/.codex/skills/autobuild/references/PHASE-EXECUTION.md
@@ -1,0 +1,527 @@
+# Phase Execution Reference
+
+> Phase ordering, parallel detection, dependency resolution, and execution batching.
+
+## Phase Identification
+
+### Parsing Phase Overview Table
+
+Plans contain a phase overview table:
+
+```markdown
+| Phase | Name | Depends On | Parallel With | Estimate | Status |
+|-------|------|------------|---------------|----------|--------|
+| 0 | Bootstrap | - | - | 5 | ⬜ |
+| 1 | Setup | 0 | - | 3 | ⬜ |
+| 2A | Backend | 1 | 2B, 2C | 8 | ⬜ |
+| 2B | Frontend | 1 | 2A, 2C | 5 | ⬜ |
+| 2C | Tests | 1 | 2A, 2B | 3 | ⬜ |
+| 3 | Integration | 2A, 2B, 2C | - | 5 | ⬜ |
+```
+
+### Phase ID Normalization
+
+| Raw ID | Normalized |
+|--------|------------|
+| `Phase 0` | `0` |
+| `Phase 1` | `1` |
+| `Phase 2A` | `2a` |
+| `Phase 2-A` | `2a` |
+| `2A` | `2a` |
+| `Phase 2a` | `2a` |
+
+**Rules:**
+1. Remove "Phase" prefix
+2. Lowercase all letters
+3. Remove spaces and hyphens
+4. Keep alphanumeric only
+
+### Detecting Parallel Groups
+
+Phases are parallel if they share "Parallel With" entries:
+
+```
+Phase 2A: Parallel With [2B, 2C]
+Phase 2B: Parallel With [2A, 2C]
+Phase 2C: Parallel With [2A, 2B]
+
+-> Parallel Group: [2A, 2B, 2C]
+```
+
+**Algorithm:**
+```python
+def find_parallel_groups(phases):
+    groups = []
+    seen = set()
+
+    for phase in phases:
+        if phase.id in seen:
+            continue
+
+        if phase.parallel_with:
+            group = {phase.id} | set(phase.parallel_with)
+            groups.append(sorted(group))
+            seen.update(group)
+        else:
+            groups.append([phase.id])
+            seen.add(phase.id)
+
+    return groups
+```
+
+---
+
+## Dependency Resolution
+
+### Building Dependency Graph
+
+```python
+def build_dependency_graph(phases):
+    graph = {}
+    for phase in phases:
+        graph[phase.id] = {
+            "depends_on": phase.depends_on or [],
+            "parallel_with": phase.parallel_with or [],
+            "blocks": []  # Computed below
+        }
+
+    # Compute reverse dependencies (blocks)
+    for phase_id, deps in graph.items():
+        for dep in deps["depends_on"]:
+            graph[dep]["blocks"].append(phase_id)
+
+    return graph
+```
+
+### Example Graph
+
+```
+Phase 0: depends_on=[], blocks=[1]
+Phase 1: depends_on=[0], blocks=[2a, 2b, 2c]
+Phase 2A: depends_on=[1], parallel_with=[2b, 2c], blocks=[3]
+Phase 2B: depends_on=[1], parallel_with=[2a, 2c], blocks=[3]
+Phase 2C: depends_on=[1], parallel_with=[2a, 2b], blocks=[3]
+Phase 3: depends_on=[2a, 2b, 2c], blocks=[]
+```
+
+### Topological Sort
+
+Sort phases respecting dependencies:
+
+```python
+def topological_sort(graph):
+    result = []
+    in_degree = {node: len(deps["depends_on"]) for node, deps in graph.items()}
+    queue = [node for node, degree in in_degree.items() if degree == 0]
+
+    while queue:
+        # Sort queue to process parallel groups together
+        queue.sort()
+        node = queue.pop(0)
+        result.append(node)
+
+        for blocked in graph[node]["blocks"]:
+            in_degree[blocked] -= 1
+            if in_degree[blocked] == 0:
+                queue.append(blocked)
+
+    return result
+```
+
+### Detecting Circular Dependencies
+
+```python
+def has_cycle(graph):
+    visited = set()
+    rec_stack = set()
+
+    def dfs(node):
+        visited.add(node)
+        rec_stack.add(node)
+
+        for dep in graph[node]["depends_on"]:
+            if dep not in visited:
+                if dfs(dep):
+                    return True
+            elif dep in rec_stack:
+                return True
+
+        rec_stack.remove(node)
+        return False
+
+    for node in graph:
+        if node not in visited:
+            if dfs(node):
+                return True
+
+    return False
+```
+
+**If cycle detected:**
+```
+DEPENDENCY CYCLE DETECTED
+=========================
+
+Phases involved: 2A -> 3 -> 2A
+
+This plan has circular dependencies and cannot be executed.
+Please fix the plan's "Depends On" column.
+
+[EXIT - Invalid plan]
+```
+
+---
+
+## Execution Batching
+
+### Creating Execution Batches
+
+Group phases into sequential batches:
+
+```python
+def create_execution_batches(phases, parallel_groups):
+    batches = []
+    executed = set()
+    remaining = set(p.id for p in phases)
+
+    while remaining:
+        # Find phases whose dependencies are all met
+        ready = []
+        for phase_id in remaining:
+            deps = graph[phase_id]["depends_on"]
+            if all(d in executed for d in deps):
+                ready.append(phase_id)
+
+        if not ready:
+            raise Exception("Deadlock - unmet dependencies")
+
+        # Check if ready phases form a parallel group
+        for group in parallel_groups:
+            if set(group).issubset(set(ready)):
+                batches.append({"type": "parallel", "phases": group})
+                executed.update(group)
+                remaining -= set(group)
+                break
+        else:
+            # Execute first ready phase sequentially
+            phase = ready[0]
+            batches.append({"type": "sequential", "phases": [phase]})
+            executed.add(phase)
+            remaining.remove(phase)
+
+    return batches
+```
+
+### Example Batch Output
+
+```
+EXECUTION BATCHES
+=================
+
+Batch 1: sequential
+  - Phase 0 (Bootstrap)
+
+Batch 2: sequential
+  - Phase 1 (Setup)
+
+Batch 3: parallel
+  - Phase 2A (Backend)
+  - Phase 2B (Frontend)
+  - Phase 2C (Tests)
+
+Batch 4: sequential
+  - Phase 3 (Integration)
+```
+
+---
+
+## Execution Order Visualization
+
+### ASCII Diagram
+
+```
+EXECUTION ORDER
+===============
+
+[Phase 0: Bootstrap]
+        |
+        v
+[Phase 1: Setup]
+        |
+        +--------+--------+
+        |        |        |
+        v        v        v
+    [2A]     [2B]     [2C]     <- PARALLEL
+        |        |        |
+        +--------+--------+
+                |
+                v
+    [Phase 3: Integration]
+```
+
+### Mermaid Diagram (for plan documentation)
+
+```mermaid
+graph TD
+    P0[Phase 0: Bootstrap] --> P1[Phase 1: Setup]
+    P1 --> P2A[Phase 2A: Backend]
+    P1 --> P2B[Phase 2B: Frontend]
+    P1 --> P2C[Phase 2C: Tests]
+    P2A --> P3[Phase 3: Integration]
+    P2B --> P3
+    P2C --> P3
+
+    style P2A fill:#e1f5fe
+    style P2B fill:#e1f5fe
+    style P2C fill:#e1f5fe
+
+    subgraph parallel[Parallel Execution]
+        P2A
+        P2B
+        P2C
+    end
+```
+
+---
+
+## Phase Status Transitions
+
+```
+           +------------------+
+           |     pending      |
+           +--------+---------+
+                    |
+           (dependencies met)
+                    |
+                    v
+           +------------------+
+           |     running      |<----+
+           +--------+---------+     |
+                    |               |
+         +----------+----------+    |
+         |                     |    |
+    (success)             (failure) |
+         |                     |    |
+         v                     v    |
++------------------+  +------------------+
+|    complete      |  |     retry        |--+ (attempt < max)
++------------------+  +--------+---------+
+                               |
+                          (attempt >= max)
+                               |
+                               v
+                      +------------------+
+                      |     failed       |
+                      +------------------+
+```
+
+### Status Transition Rules
+
+| From | To | Condition |
+|------|-----|-----------|
+| pending | running | All dependencies complete |
+| running | complete | Sub-agent success + verification passed |
+| running | failed | Sub-agent failed + max retries reached |
+| failed | running | Resume with --resume (resets attempt count) |
+| complete | - | Terminal state |
+
+---
+
+## Handling Blocked Phases
+
+When a phase fails, update blocked phases:
+
+```python
+def update_blocked_phases(failed_phase, graph, states):
+    blocked = set()
+
+    def find_blocked(phase_id):
+        for downstream in graph[phase_id]["blocks"]:
+            if downstream not in blocked:
+                blocked.add(downstream)
+                states[downstream]["status"] = "blocked"
+                states[downstream]["error"] = {
+                    "type": "blocked",
+                    "message": f"Blocked by failed phase {failed_phase}"
+                }
+                find_blocked(downstream)
+
+    find_blocked(failed_phase)
+    return blocked
+```
+
+### Blocked Phase State
+
+```json
+{
+  "phase_id": "3",
+  "phase_name": "Integration",
+  "status": "blocked",
+  "error": {
+    "type": "blocked",
+    "message": "Blocked by failed phase 2a",
+    "blocking_phase": "2a"
+  }
+}
+```
+
+---
+
+## Resume Logic
+
+### Determining Resume Point
+
+```python
+def find_resume_point(states, batches):
+    for batch in batches:
+        for phase_id in batch["phases"]:
+            state = states.get(phase_id)
+            if not state:
+                return batch  # New phase
+            if state["status"] in ("pending", "failed", "running", "blocked"):
+                return batch
+
+    return None  # All complete
+```
+
+### Resume Scenarios
+
+| State | Resume Action |
+|-------|---------------|
+| Phase 2A: failed | Retry Phase 2A (reset attempt count) |
+| Phase 2A: running | Re-run Phase 2A (may have been interrupted) |
+| Phase 2A: complete, 2B: pending | Start Phase 2B |
+| Phase 3: blocked by 2A | First resume 2A |
+| All complete | Output completion summary |
+
+---
+
+## Parallel Execution
+
+### Launching Parallel Sub-Agents
+
+```
+LAUNCHING PARALLEL BATCH
+========================
+
+Phases: 2A, 2B, 2C
+Method: Concurrent Task tool calls with run_in_background: true
+
+Task 2A: [launched] -> task-id-abc
+Task 2B: [launched] -> task-id-def
+Task 2C: [launched] -> task-id-ghi
+
+Waiting for all tasks to complete...
+```
+
+### Collecting Parallel Results
+
+```python
+def execute_parallel_batch(phases):
+    # Launch all sub-agents
+    task_ids = {}
+    for phase in phases:
+        task_id = launch_subagent(phase, run_in_background=True)
+        task_ids[phase.id] = task_id
+
+    # Wait for all to complete
+    results = {}
+    for phase_id, task_id in task_ids.items():
+        result = wait_for_task(task_id)
+        results[phase_id] = result
+
+    return results
+```
+
+### Parallel Batch Completion
+
+```
+PARALLEL BATCH COMPLETE
+=======================
+
+Results:
+| Phase | Status | Duration |
+|-------|--------|----------|
+| 2A | complete | 10m 15s |
+| 2B | complete | 8m 30s |
+| 2C | complete | 5m 45s |
+
+All phases in batch successful.
+Proceeding to next batch...
+```
+
+### Partial Parallel Failure
+
+```
+PARALLEL BATCH PARTIAL FAILURE
+==============================
+
+Results:
+| Phase | Status | Duration |
+|-------|--------|----------|
+| 2A | FAILED | 15m 00s |
+| 2B | complete | 8m 30s |
+| 2C | complete | 5m 45s |
+
+Phase 2A failed. Initiating retry...
+
+[After retry]
+
+Phase 2A failed after retry.
+Successful phases (2B, 2C) preserved.
+Phase 3 blocked until 2A succeeds.
+
+AUTOBUILD HALTED
+```
+
+---
+
+## Dry Run Mode
+
+With `--dry-run` flag, validate and display without executing:
+
+```
+DRY RUN - EXECUTION PREVIEW
+============================
+
+Plan: docs/feature-plan.md
+Commit Mode: auto
+
+Stack Detection:
+- Language: TypeScript
+- Framework: Express
+- Tests: Jest
+
+Execution Order:
+
+Batch 1 (sequential):
+  [0] Bootstrap (5 pts)
+      Dependencies: none
+      Tasks: 4
+
+Batch 2 (sequential):
+  [1] Setup (3 pts)
+      Dependencies: [0]
+      Tasks: 3
+
+Batch 3 (parallel):
+  [2A] Backend (8 pts)
+       Dependencies: [1]
+       Tasks: 5
+  [2B] Frontend (5 pts)
+       Dependencies: [1]
+       Tasks: 4
+  [2C] Tests (3 pts)
+       Dependencies: [1]
+       Tasks: 3
+
+Batch 4 (sequential):
+  [3] Integration (5 pts)
+      Dependencies: [2A, 2B, 2C]
+      Tasks: 4
+
+Total: 6 phases, 24 points, 23 tasks
+
+Validation: PASSED
+Ready to execute with: /autobuild docs/feature-plan.md --commit=auto
+```

--- a/.codex/skills/autobuild/references/STATE-FILES.md
+++ b/.codex/skills/autobuild/references/STATE-FILES.md
@@ -1,0 +1,521 @@
+# State Files Reference
+
+> Complete specification for .autobuild/ directory structure and state file format.
+
+## Directory Structure
+
+```
+.autobuild/
+  config.json           # Execution configuration (stack, commands, args)
+  commits.sh            # Generated commit script (--commit=message-only)
+  phases/
+    phase-0.json        # State file per phase
+    phase-1.json
+    phase-2a.json       # Parallel phases use alpha suffix
+    phase-2b.json
+    phase-2c.json
+    phase-3.json
+    ...
+  logs/
+    execution.log       # Overall execution log
+    phase-0.log         # Truncated sub-agent output per phase
+    phase-1.log
+    ...
+```
+
+---
+
+## config.json
+
+Created during initialization, stores execution parameters.
+
+```json
+{
+  "version": "1.0.0",
+  "plan_path": "docs/feature-plan.md",
+  "commit_mode": "auto",
+  "started_at": "2025-01-25T10:00:00Z",
+  "last_updated": "2025-01-25T10:30:00Z",
+  "stack": {
+    "language": "typescript",
+    "framework": "express",
+    "package_manager": "pnpm",
+    "test_framework": "jest",
+    "linter": "eslint",
+    "formatter": "prettier"
+  },
+  "commands": {
+    "lint": "pnpm run lint",
+    "format": "pnpm run format:check",
+    "typecheck": "pnpm run typecheck",
+    "test": "pnpm test"
+  },
+  "phases": {
+    "total": 6,
+    "completed": 3,
+    "failed": 1,
+    "pending": 2
+  }
+}
+```
+
+### Config Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `version` | string | Autobuild state format version |
+| `plan_path` | string | Path to plan document |
+| `commit_mode` | enum | "auto", "message-only", or "single" |
+| `started_at` | ISO 8601 | Execution start time |
+| `last_updated` | ISO 8601 | Last state change time |
+| `stack` | object | Detected technology stack |
+| `commands` | object | Quality gate commands |
+| `phases` | object | Phase count summary |
+
+---
+
+## Phase State Files
+
+Each phase gets a state file: `.autobuild/phases/phase-{id}.json`
+
+### Phase Naming
+
+| Phase ID | State File |
+|----------|------------|
+| Phase 0 | `phase-0.json` |
+| Phase 1 | `phase-1.json` |
+| Phase 2A | `phase-2a.json` |
+| Phase 2B | `phase-2b.json` |
+| Phase 3 | `phase-3.json` |
+
+**Normalize phase IDs**: Remove spaces, lowercase, remove punctuation.
+
+### Complete Phase State Format
+
+```json
+{
+  "phase_id": "2a",
+  "phase_name": "Backend API",
+  "status": "complete",
+  "attempt": 1,
+  "max_attempts": 2,
+  "timestamps": {
+    "started": "2025-01-25T10:15:00Z",
+    "completed": "2025-01-25T10:25:00Z",
+    "duration_seconds": 600
+  },
+  "dependencies": {
+    "depends_on": ["1"],
+    "parallel_with": ["2b", "2c"],
+    "blocks": ["3"]
+  },
+  "execution": {
+    "subagent_id": "task-abc123",
+    "subagent_model": "sonnet",
+    "tasks_total": 4,
+    "tasks_completed": 4
+  },
+  "quality_gates": {
+    "lint": {
+      "passed": true,
+      "command": "pnpm run lint",
+      "output_summary": "No errors"
+    },
+    "format": {
+      "passed": true,
+      "command": "pnpm run format:check",
+      "output_summary": "All files formatted"
+    },
+    "typecheck": {
+      "passed": true,
+      "command": "pnpm run typecheck",
+      "output_summary": "No type errors"
+    },
+    "test": {
+      "passed": true,
+      "command": "pnpm test",
+      "output_summary": "47 tests passed, 0 failed",
+      "coverage": "87%"
+    }
+  },
+  "verification": {
+    "subagent_claimed": "complete",
+    "fresh_verification": "passed",
+    "verified_at": "2025-01-25T10:26:00Z"
+  },
+  "commit": {
+    "message": "feat(api): implement JWT token validation\n\n- Add validateToken function\n- Add token refresh endpoint\n- Add comprehensive test coverage",
+    "type": "feat",
+    "scope": "api",
+    "files_created": [
+      "src/api/auth.ts",
+      "src/api/auth.test.ts"
+    ],
+    "files_modified": [
+      "src/api/routes.ts"
+    ],
+    "files_deleted": [],
+    "committed": true,
+    "commit_sha": "a1b2c3d"
+  },
+  "plan_updates": {
+    "tasks_checked": 4,
+    "dod_checked": 6,
+    "status_updated": true
+  },
+  "error": null
+}
+```
+
+### Status Values
+
+| Status | Description |
+|--------|-------------|
+| `pending` | Not yet started |
+| `running` | Sub-agent currently executing |
+| `complete` | Successfully finished and verified |
+| `failed` | Failed after max attempts |
+| `blocked` | Dependencies not met |
+
+### Minimal State (Pending Phase)
+
+```json
+{
+  "phase_id": "3",
+  "phase_name": "Integration",
+  "status": "pending",
+  "attempt": 0,
+  "max_attempts": 2,
+  "timestamps": {},
+  "dependencies": {
+    "depends_on": ["2a", "2b", "2c"],
+    "parallel_with": [],
+    "blocks": []
+  },
+  "execution": null,
+  "quality_gates": null,
+  "verification": null,
+  "commit": null,
+  "plan_updates": null,
+  "error": null
+}
+```
+
+### Failed Phase State
+
+```json
+{
+  "phase_id": "2a",
+  "phase_name": "Backend API",
+  "status": "failed",
+  "attempt": 2,
+  "max_attempts": 2,
+  "timestamps": {
+    "started": "2025-01-25T10:15:00Z",
+    "failed": "2025-01-25T10:35:00Z",
+    "duration_seconds": 1200
+  },
+  "dependencies": {
+    "depends_on": ["1"],
+    "parallel_with": ["2b", "2c"],
+    "blocks": ["3"]
+  },
+  "execution": {
+    "subagent_id": "task-xyz789",
+    "subagent_model": "sonnet",
+    "tasks_total": 4,
+    "tasks_completed": 2
+  },
+  "quality_gates": {
+    "lint": {
+      "passed": true,
+      "command": "pnpm run lint",
+      "output_summary": "No errors"
+    },
+    "format": {
+      "passed": true,
+      "command": "pnpm run format:check",
+      "output_summary": "All files formatted"
+    },
+    "typecheck": {
+      "passed": true,
+      "command": "pnpm run typecheck",
+      "output_summary": "No type errors"
+    },
+    "test": {
+      "passed": false,
+      "command": "pnpm test",
+      "output_summary": "3 tests failed",
+      "failures": [
+        "src/api/auth.test.ts:45 - should validate token",
+        "src/api/auth.test.ts:67 - should refresh token",
+        "src/api/auth.test.ts:89 - should handle expired token"
+      ]
+    }
+  },
+  "verification": {
+    "subagent_claimed": "complete",
+    "fresh_verification": "failed",
+    "verified_at": "2025-01-25T10:35:00Z"
+  },
+  "commit": null,
+  "plan_updates": null,
+  "error": {
+    "type": "test_failure",
+    "message": "3 tests failed after retry",
+    "details": "Tests in src/api/auth.test.ts failing on token validation logic",
+    "attempt_1_error": "3 tests failed - token validation incorrect",
+    "attempt_2_error": "3 tests failed - same failures after retry"
+  }
+}
+```
+
+---
+
+## Log Files
+
+### execution.log
+
+Overall execution log with timestamps:
+
+```
+[2025-01-25T10:00:00Z] AUTOBUILD STARTED
+[2025-01-25T10:00:00Z] Plan: docs/feature-plan.md
+[2025-01-25T10:00:00Z] Commit mode: auto
+[2025-01-25T10:00:01Z] Stack detected: typescript/express
+[2025-01-25T10:00:02Z] Phases identified: 6
+[2025-01-25T10:00:02Z] Execution order: [0] -> [1] -> [2a,2b,2c] -> [3]
+
+[2025-01-25T10:00:03Z] PHASE 0 STARTED
+[2025-01-25T10:05:00Z] PHASE 0 COMPLETE - chore(bootstrap): add quality tools
+[2025-01-25T10:05:01Z] Committed: a1b2c3d
+
+[2025-01-25T10:05:02Z] PHASE 1 STARTED
+[2025-01-25T10:10:00Z] PHASE 1 COMPLETE - feat(db): add user schema
+[2025-01-25T10:10:01Z] Committed: b2c3d4e
+
+[2025-01-25T10:10:02Z] PARALLEL BATCH STARTED: 2a, 2b, 2c
+[2025-01-25T10:25:00Z] PHASE 2B COMPLETE - feat(ui): add login form
+[2025-01-25T10:27:00Z] PHASE 2C COMPLETE - test(auth): add edge cases
+[2025-01-25T10:30:00Z] PHASE 2A FAILED - tests failing (attempt 1)
+[2025-01-25T10:30:01Z] PHASE 2A RETRY STARTED
+[2025-01-25T10:35:00Z] PHASE 2A FAILED - tests failing (attempt 2)
+[2025-01-25T10:35:01Z] PARALLEL BATCH FAILED: 2a failed, 2b+2c complete
+
+[2025-01-25T10:35:02Z] AUTOBUILD HALTED
+[2025-01-25T10:35:02Z] Completed: 4 phases
+[2025-01-25T10:35:02Z] Failed: 1 phase (2a)
+[2025-01-25T10:35:02Z] Remaining: 1 phase (3)
+```
+
+### phase-{id}.log
+
+Truncated sub-agent conversation for debugging:
+
+```
+=== PHASE 2A SUB-AGENT LOG ===
+Started: 2025-01-25T10:15:00Z
+Model: sonnet
+
+--- TASK 1: Create auth types ---
+[Reading plan section...]
+[Writing test: src/api/auth.test.ts]
+[Running test - expected FAIL]
+[Writing implementation: src/api/auth.ts]
+[Running test - PASS]
+
+--- TASK 2: Implement validateToken ---
+[Writing test...]
+[Running test - expected FAIL]
+[Writing implementation...]
+[Running test - PASS]
+
+--- QUALITY GATES ---
+Lint: pnpm run lint -> PASS
+Format: pnpm run format:check -> PASS
+Typecheck: pnpm run typecheck -> PASS
+Tests: pnpm test -> PASS (47 tests)
+
+--- PLAN UPDATES ---
+Checked: 4 tasks
+DoD: 6 items
+
+--- RESULT ---
+Status: complete
+Commit: feat(api): implement JWT token validation
+
+=== END PHASE 2A LOG ===
+```
+
+---
+
+## commits.sh (--commit=message-only)
+
+Generated script for manual commit execution:
+
+```bash
+#!/bin/bash
+# Generated by autobuild
+# Plan: docs/feature-plan.md
+# Generated: 2025-01-25T10:35:00Z
+
+set -e
+
+echo "Committing Phase 0: Bootstrap"
+git add .eslintrc.json .prettierrc tsconfig.json jest.config.js
+git commit -m "$(cat <<'EOF'
+chore(bootstrap): add quality tools
+
+- Add ESLint configuration
+- Add Prettier configuration
+- Add TypeScript configuration
+- Add Jest configuration
+EOF
+)"
+
+echo "Committing Phase 1: Setup"
+git add prisma/schema.prisma prisma/migrations/
+git commit -m "$(cat <<'EOF'
+feat(db): add user schema
+
+- Create user model with auth fields
+- Add initial migration
+EOF
+)"
+
+echo "Committing Phase 2A: Backend API"
+git add src/api/auth.ts src/api/auth.test.ts src/api/routes.ts
+git commit -m "$(cat <<'EOF'
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+
+# ... more phases ...
+
+echo "All commits complete!"
+```
+
+---
+
+## State File Operations
+
+### Creating State File
+
+```python
+# Pseudocode for state file creation
+def create_phase_state(phase_id, phase_name, dependencies):
+    return {
+        "phase_id": normalize_id(phase_id),
+        "phase_name": phase_name,
+        "status": "pending",
+        "attempt": 0,
+        "max_attempts": 2,
+        "timestamps": {},
+        "dependencies": dependencies,
+        "execution": None,
+        "quality_gates": None,
+        "verification": None,
+        "commit": None,
+        "plan_updates": None,
+        "error": None
+    }
+```
+
+### Updating State File
+
+```python
+# Pseudocode for state update
+def update_phase_state(state_file, updates):
+    state = read_json(state_file)
+    state.update(updates)
+    state["timestamps"]["last_updated"] = now_iso()
+    write_json(state_file, state)
+```
+
+### Reading State for Resume
+
+```python
+# Pseudocode for resume logic
+def get_resume_point():
+    states = read_all_phase_states()
+
+    for phase in topological_order(states):
+        if phase["status"] == "pending":
+            return phase["phase_id"]
+        if phase["status"] == "failed":
+            return phase["phase_id"]  # Retry failed phase
+        if phase["status"] == "running":
+            return phase["phase_id"]  # Resume interrupted
+
+    return None  # All complete
+```
+
+---
+
+## Gitignore Recommendation
+
+Add to `.gitignore`:
+
+```gitignore
+# Autobuild state (optional - some teams prefer to track)
+.autobuild/
+
+# Or keep state but ignore logs
+# .autobuild/logs/
+```
+
+**Arguments for tracking .autobuild/:**
+- Preserves execution history
+- Enables team visibility into build progress
+- Supports debugging failed builds
+
+**Arguments against tracking:**
+- State is ephemeral and regenerable
+- Can contain large log files
+- May conflict between team members
+
+---
+
+## State File Validation
+
+Before using state files, validate:
+
+```json
+{
+  "required_fields": [
+    "phase_id",
+    "phase_name",
+    "status",
+    "attempt",
+    "max_attempts"
+  ],
+  "valid_statuses": [
+    "pending",
+    "running",
+    "complete",
+    "failed",
+    "blocked"
+  ]
+}
+```
+
+If validation fails, treat state as corrupted and prompt user:
+
+```
+STATE FILE VALIDATION FAILED
+============================
+
+File: .autobuild/phases/phase-2a.json
+Error: Missing required field 'status'
+
+Options:
+1. Delete corrupted state and re-run phase
+2. Manually fix state file
+3. Start fresh with --fresh flag
+
+[WAITING FOR USER INPUT]
+```

--- a/.codex/skills/autobuild/references/SUBAGENT-PROMPTS.md
+++ b/.codex/skills/autobuild/references/SUBAGENT-PROMPTS.md
@@ -1,0 +1,595 @@
+# Sub-Agent Prompts Reference
+
+> Exact prompts for launching phase execution sub-agents. Copy these templates exactly.
+
+## Core Principle
+
+Each phase runs in its own sub-agent to:
+1. **Isolate context** - Sub-agent starts fresh, no accumulated context
+2. **Enable parallelism** - Multiple sub-agents can run concurrently
+3. **Prevent exhaustion** - Main agent context stays minimal
+4. **Support recovery** - Failed sub-agent doesn't corrupt main state
+
+---
+
+## Sequential Phase Prompt
+
+Use this exact template for sequential phases:
+
+```
+You are executing Phase {PHASE_ID} of an implementation plan.
+
+═══════════════════════════════════════════════════════════════
+PHASE DETAILS
+═══════════════════════════════════════════════════════════════
+
+Phase ID: {PHASE_ID}
+Phase Name: {PHASE_NAME}
+Plan File: {PLAN_PATH}
+
+═══════════════════════════════════════════════════════════════
+YOUR TASK
+═══════════════════════════════════════════════════════════════
+
+1. Read the plan file at {PLAN_PATH}
+2. Find the section for Phase {PHASE_ID}: {PHASE_NAME}
+3. Execute EACH task following the 5-step TDD micro-structure:
+   - Step 1: Write the failing test
+   - Step 2: Run test, verify it FAILS (mandatory - must see failure)
+   - Step 3: Write minimal implementation
+   - Step 4: Run test, verify it PASSES (mandatory - must see pass)
+   - Step 5: Stage files (do not commit)
+
+   **TDD ENFORCEMENT - STOP IMMEDIATELY IF:**
+   | Rule | Violation |
+   |------|-----------|
+   | Test before code | Implementation exists without test |
+   | Verify RED | Test passes immediately (testing existing behavior) |
+   | Minimal code | Adding features beyond current test |
+   | Verify GREEN | Test not run after implementation |
+   | No regressions | Other tests now fail |
+
+   Read `superplan/references/TDD-DISCIPLINE.md` for full TDD rules.
+
+4. After ALL tasks complete, run quality gates:
+   - Lint: {LINT_COMMAND}
+   - Format: {FORMAT_COMMAND}
+   - Typecheck: {TYPECHECK_COMMAND}
+   - Test: {TEST_COMMAND}
+
+   Read `superbuild/references/ENFORCEMENT-GUIDE.md` for:
+   - Stack-specific commands (JS/TS, Python, Go, Rust)
+   - Exit code interpretation
+   - Evidence requirements by claim
+   - Flaky test detection
+
+5. Update the plan file:
+   - Check off completed tasks (- [ ] -> - [x])
+   - Check off Definition of Done items
+   - Update phase status in overview table (if present)
+
+   Read `superbuild/references/PLAN-UPDATES.md` for:
+   - Checkbox pattern recognition
+   - Status indicator patterns
+   - Verification steps
+
+6. **VERIFY DEFINITION OF DONE (CRITICAL)**:
+
+   For EACH DoD item, verify the USER-FACING BEHAVIOR actually works:
+
+   - "Section displays X" → Trace: Is the load function called? Is the handler wired up?
+   - "Feature Y works" → Can you demonstrate end-to-end, not just unit test?
+   - "Component Z appears" → Is it actually rendered, or just defined?
+
+   **THE INTEGRATION TRAP:**
+   Creating a function is NOT completing a task. The function must be:
+   - Called from the appropriate entry point
+   - Have its result handled
+   - Actually produce the user-facing behavior
+
+   If you created `LoadDiscoveries()` but it's never called from `Init()`,
+   the DoD "displays discoveries" is NOT met. The phase is NOT complete.
+
+   **NO TODOs:** If you write `// TODO: Handle this in Phase X`, the phase
+   has FAILED. Complete the integration or report failure.
+
+═══════════════════════════════════════════════════════════════
+CRITICAL RULES
+═══════════════════════════════════════════════════════════════
+
+- Do NOT skip the TDD cycle - tests MUST fail first
+- Do NOT run git commit commands
+- Do NOT modify other phases
+- Do NOT proceed if quality gates fail
+- STOP immediately if you cannot complete a task
+- Do NOT mark phase complete if code exists but isn't wired up
+- Do NOT leave TODOs for core functionality
+- VERIFY user-facing behavior works, not just that code exists
+
+═══════════════════════════════════════════════════════════════
+RETURN FORMAT (JSON)
+═══════════════════════════════════════════════════════════════
+
+When complete, output EXACTLY this JSON structure:
+
+```json
+{
+  "phase_id": "{PHASE_ID}",
+  "status": "complete" | "failed",
+  "tasks": {
+    "total": <number>,
+    "completed": <number>
+  },
+  "quality_gates": {
+    "lint": {"passed": true|false, "output": "<summary>"},
+    "format": {"passed": true|false, "output": "<summary>"},
+    "typecheck": {"passed": true|false, "output": "<summary>"},
+    "test": {"passed": true|false, "output": "<summary>", "count": <number>}
+  },
+  "commit_message": "<conventional commit message>",
+  "files": {
+    "created": ["path/to/file.ts", ...],
+    "modified": ["path/to/file.ts", ...],
+    "deleted": []
+  },
+  "plan_updated": true|false,
+  "error": null | {"type": "<type>", "message": "<details>"}
+}
+```
+
+Begin execution now.
+```
+
+---
+
+## Parallel Phase Prompt
+
+Use this for phases in a parallel batch. Identical to sequential but emphasizes isolation:
+
+```
+You are executing Phase {PHASE_ID} of an implementation plan.
+
+THIS IS A PARALLEL PHASE - Other phases ({SIBLING_PHASES}) are running concurrently.
+Do NOT modify files that belong to sibling phases.
+
+═══════════════════════════════════════════════════════════════
+PHASE DETAILS
+═══════════════════════════════════════════════════════════════
+
+Phase ID: {PHASE_ID}
+Phase Name: {PHASE_NAME}
+Plan File: {PLAN_PATH}
+Parallel With: {SIBLING_PHASES}
+
+═══════════════════════════════════════════════════════════════
+YOUR TASK
+═══════════════════════════════════════════════════════════════
+
+1. Read the plan file at {PLAN_PATH}
+2. Find the section for Phase {PHASE_ID}: {PHASE_NAME}
+3. Execute EACH task following the 5-step TDD micro-structure:
+   - Step 1: Write the failing test
+   - Step 2: Run test, verify it FAILS (mandatory - must see failure)
+   - Step 3: Write minimal implementation
+   - Step 4: Run test, verify it PASSES (mandatory - must see pass)
+   - Step 5: Stage files (do not commit)
+
+   **TDD ENFORCEMENT - STOP IMMEDIATELY IF:**
+   | Rule | Violation |
+   |------|-----------|
+   | Test before code | Implementation exists without test |
+   | Verify RED | Test passes immediately (testing existing behavior) |
+   | Minimal code | Adding features beyond current test |
+   | Verify GREEN | Test not run after implementation |
+   | No regressions | Other tests now fail |
+
+   Read `superplan/references/TDD-DISCIPLINE.md` for full TDD rules.
+
+4. After ALL tasks complete, run quality gates:
+   - Lint: {LINT_COMMAND}
+   - Format: {FORMAT_COMMAND}
+   - Typecheck: {TYPECHECK_COMMAND}
+   - Test: {TEST_COMMAND}
+
+   Read `superbuild/references/ENFORCEMENT-GUIDE.md` for:
+   - Stack-specific commands (JS/TS, Python, Go, Rust)
+   - Exit code interpretation
+   - Evidence requirements by claim
+   - Flaky test detection
+
+5. Update the plan file:
+   - Check off completed tasks for YOUR PHASE ONLY
+   - Check off Definition of Done items for YOUR PHASE ONLY
+   - Update YOUR phase status in overview table
+
+   Read `superbuild/references/PLAN-UPDATES.md` for:
+   - Checkbox pattern recognition
+   - Status indicator patterns
+   - Verification steps
+
+6. **VERIFY DEFINITION OF DONE (CRITICAL)**:
+
+   For EACH DoD item, verify the USER-FACING BEHAVIOR actually works:
+
+   - "Section displays X" → Trace: Is the load function called? Is the handler wired up?
+   - "Feature Y works" → Can you demonstrate end-to-end, not just unit test?
+   - "Component Z appears" → Is it actually rendered, or just defined?
+
+   **THE INTEGRATION TRAP:**
+   Creating a function is NOT completing a task. The function must be:
+   - Called from the appropriate entry point
+   - Have its result handled
+   - Actually produce the user-facing behavior
+
+   **NO TODOs:** If you write `// TODO: Handle this in Phase X`, the phase
+   has FAILED. Complete the integration or report failure.
+
+═══════════════════════════════════════════════════════════════
+PARALLEL EXECUTION RULES
+═══════════════════════════════════════════════════════════════
+
+- ONLY modify files listed in YOUR phase section
+- Do NOT touch files that sibling phases might be editing
+- If you need a shared file, coordinate via imports only
+- Siblings phases are: {SIBLING_PHASES}
+
+═══════════════════════════════════════════════════════════════
+CRITICAL RULES
+═══════════════════════════════════════════════════════════════
+
+- Do NOT skip the TDD cycle - tests MUST fail first
+- Do NOT run git commit commands
+- Do NOT modify other phases
+- Do NOT proceed if quality gates fail
+- STOP immediately if you cannot complete a task
+- Do NOT mark phase complete if code exists but isn't wired up
+- Do NOT leave TODOs for core functionality
+- VERIFY user-facing behavior works, not just that code exists
+
+═══════════════════════════════════════════════════════════════
+RETURN FORMAT (JSON)
+═══════════════════════════════════════════════════════════════
+
+When complete, output EXACTLY this JSON structure:
+
+```json
+{
+  "phase_id": "{PHASE_ID}",
+  "status": "complete" | "failed",
+  "tasks": {
+    "total": <number>,
+    "completed": <number>
+  },
+  "quality_gates": {
+    "lint": {"passed": true|false, "output": "<summary>"},
+    "format": {"passed": true|false, "output": "<summary>"},
+    "typecheck": {"passed": true|false, "output": "<summary>"},
+    "test": {"passed": true|false, "output": "<summary>", "count": <number>}
+  },
+  "commit_message": "<conventional commit message>",
+  "files": {
+    "created": ["path/to/file.ts", ...],
+    "modified": ["path/to/file.ts", ...],
+    "deleted": []
+  },
+  "plan_updated": true|false,
+  "error": null | {"type": "<type>", "message": "<details>"}
+}
+```
+
+Begin execution now.
+```
+
+---
+
+## Retry Phase Prompt
+
+When retrying a failed phase, include context about the previous failure:
+
+```
+You are RETRYING Phase {PHASE_ID} of an implementation plan.
+
+═══════════════════════════════════════════════════════════════
+RETRY CONTEXT
+═══════════════════════════════════════════════════════════════
+
+This is attempt {ATTEMPT} of {MAX_ATTEMPTS}.
+
+Previous failure:
+  Type: {PREVIOUS_ERROR_TYPE}
+  Message: {PREVIOUS_ERROR_MESSAGE}
+  Details: {PREVIOUS_ERROR_DETAILS}
+
+You must address the previous failure while completing the phase.
+
+═══════════════════════════════════════════════════════════════
+PHASE DETAILS
+═══════════════════════════════════════════════════════════════
+
+Phase ID: {PHASE_ID}
+Phase Name: {PHASE_NAME}
+Plan File: {PLAN_PATH}
+
+═══════════════════════════════════════════════════════════════
+YOUR TASK
+═══════════════════════════════════════════════════════════════
+
+1. Read the plan file at {PLAN_PATH}
+2. Find the section for Phase {PHASE_ID}: {PHASE_NAME}
+3. Review what was already done (check plan for [x] items)
+4. Focus on fixing the previous failure:
+   {RETRY_GUIDANCE}
+
+5. Complete any remaining tasks using TDD micro-structure
+6. Run ALL quality gates (even if some passed before)
+7. Update plan file with any newly completed items
+
+═══════════════════════════════════════════════════════════════
+CRITICAL RULES
+═══════════════════════════════════════════════════════════════
+
+- Do NOT skip the TDD cycle - tests MUST fail first
+- Do NOT run git commit commands
+- Do NOT modify other phases
+- Do NOT proceed if quality gates fail
+- STOP immediately if you cannot complete a task
+
+═══════════════════════════════════════════════════════════════
+RETURN FORMAT (JSON)
+═══════════════════════════════════════════════════════════════
+
+[Same JSON format as above]
+
+Begin retry now.
+```
+
+### Retry Guidance by Error Type
+
+| Error Type | Retry Guidance |
+|------------|----------------|
+| `test_failure` | "Fix the failing tests. Read the error messages carefully. The tests at {FILES} are failing." |
+| `lint_error` | "Fix linting errors. Run `{LINT_COMMAND}` to see current errors." |
+| `typecheck_error` | "Fix type errors. Run `{TYPECHECK_COMMAND}` to see current errors." |
+| `format_error` | "Run `{FORMAT_FIX_COMMAND}` to auto-fix formatting, then verify." |
+| `task_incomplete` | "Task {TASK_NAME} was not completed. Review the plan and finish it." |
+| `verification_mismatch` | "Previous sub-agent claimed success but verification failed. Re-run all quality gates carefully." |
+
+---
+
+## Task Tool Invocation
+
+### Sequential Phase
+
+```python
+# Pseudocode for launching sequential phase sub-agent
+result = Task(
+    description=f"Execute Phase {phase_id}",
+    prompt=format_sequential_prompt(phase, config),
+    subagent_type="general-purpose",
+    model="sonnet",  # Or inherit from config
+    run_in_background=False  # Wait for completion
+)
+```
+
+### Parallel Phases
+
+```python
+# Pseudocode for launching parallel phase sub-agents
+task_ids = []
+
+for phase in parallel_batch:
+    task_id = Task(
+        description=f"Execute Phase {phase.id}",
+        prompt=format_parallel_prompt(phase, parallel_batch, config),
+        subagent_type="general-purpose",
+        model="sonnet",
+        run_in_background=True  # Don't wait
+    )
+    task_ids.append((phase.id, task_id))
+
+# Collect results
+results = {}
+for phase_id, task_id in task_ids:
+    result = TaskOutput(task_id=task_id, block=True, timeout=600000)
+    results[phase_id] = parse_result(result)
+```
+
+---
+
+## Result Parsing
+
+### Extracting JSON from Sub-Agent Output
+
+Sub-agents may include text before/after the JSON. Extract carefully:
+
+```python
+def parse_subagent_result(output):
+    # Find JSON block in output
+    import json
+    import re
+
+    # Look for JSON between ```json and ``` markers
+    json_match = re.search(r'```json\s*(.*?)\s*```', output, re.DOTALL)
+    if json_match:
+        return json.loads(json_match.group(1))
+
+    # Try finding raw JSON object
+    json_match = re.search(r'\{[\s\S]*"phase_id"[\s\S]*\}', output)
+    if json_match:
+        return json.loads(json_match.group(0))
+
+    raise ParseError("Could not extract JSON result from sub-agent output")
+```
+
+### Validating Result Structure
+
+```python
+def validate_result(result):
+    required_fields = [
+        "phase_id",
+        "status",
+        "tasks",
+        "quality_gates",
+        "commit_message",
+        "files",
+        "plan_updated"
+    ]
+
+    for field in required_fields:
+        if field not in result:
+            raise ValidationError(f"Missing required field: {field}")
+
+    if result["status"] not in ("complete", "failed"):
+        raise ValidationError(f"Invalid status: {result['status']}")
+
+    return True
+```
+
+---
+
+## Commit Message Guidelines
+
+Sub-agents generate commit messages following Conventional Commits:
+
+### Message Format
+
+```
+<type>(<scope>): <description>
+
+<body>
+```
+
+### Type Selection
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | New feature for users |
+| `fix` | Bug fix |
+| `refactor` | Code restructure (no behavior change) |
+| `test` | Adding/updating tests |
+| `docs` | Documentation only |
+| `chore` | Build, config, dependencies |
+
+### Scope Derivation
+
+Derive scope from file paths:
+
+```
+src/api/auth.ts -> scope: api or auth
+src/components/Button.tsx -> scope: ui or button
+tests/unit/auth.test.ts -> scope: auth
+```
+
+### Example Messages
+
+```
+feat(api): add user authentication endpoints
+
+- Implement login endpoint with JWT
+- Add token refresh functionality
+- Add logout endpoint
+```
+
+```
+test(auth): add comprehensive auth test coverage
+
+- Add unit tests for token validation
+- Add integration tests for login flow
+- Add edge case tests for expired tokens
+```
+
+---
+
+## Error Handling in Sub-Agents
+
+### Sub-Agent Failure Response
+
+If a sub-agent cannot complete, it should return:
+
+```json
+{
+  "phase_id": "2a",
+  "status": "failed",
+  "tasks": {
+    "total": 5,
+    "completed": 2
+  },
+  "quality_gates": {
+    "lint": {"passed": true, "output": "No errors"},
+    "format": {"passed": true, "output": "All formatted"},
+    "typecheck": {"passed": true, "output": "No errors"},
+    "test": {"passed": false, "output": "3 tests failed", "count": 47}
+  },
+  "commit_message": null,
+  "files": {
+    "created": ["src/api/auth.ts"],
+    "modified": [],
+    "deleted": []
+  },
+  "plan_updated": false,
+  "error": {
+    "type": "test_failure",
+    "message": "3 tests failing in auth.test.ts",
+    "details": "Tests for token validation returning incorrect results. Expected user object, got null."
+  }
+}
+```
+
+### Sub-Agent Timeout
+
+If sub-agent doesn't respond within timeout:
+
+```
+SUB-AGENT TIMEOUT
+=================
+
+Phase: 2A
+Timeout: 10 minutes exceeded
+
+Actions taken:
+1. Sub-agent task terminated
+2. State file updated with timeout error
+3. Phase marked as failed
+
+Error recorded:
+{
+  "type": "timeout",
+  "message": "Sub-agent did not complete within 10 minutes",
+  "details": "Task may be stuck or too complex. Consider breaking into smaller tasks."
+}
+
+Initiating retry...
+```
+
+---
+
+## Sub-Agent Context Loading
+
+Sub-agents should load context efficiently:
+
+### What to Read
+
+1. **Plan file** - Specific phase section only
+2. **Referenced files** - Files mentioned in task descriptions
+3. **Test files** - To understand existing test patterns
+
+### What NOT to Read
+
+1. Other phase sections (unless explicit dependency)
+2. Entire codebase exploration
+3. Documentation files (unless task requires)
+4. Previous conversation history (isolated by design)
+
+### Efficient Context Pattern
+
+```
+# Good: Targeted reads
+Read: docs/feature-plan.md (find Phase 2A section)
+Read: src/api/routes.ts (modify target)
+Read: tests/api/routes.test.ts (test pattern reference)
+
+# Bad: Exploratory reads
+Read: src/**/*.ts (too broad)
+Grep: "function" (unfocused search)
+Read: README.md (not needed for execution)
+```

--- a/.codex/skills/autobuild/references/VERIFICATION.md
+++ b/.codex/skills/autobuild/references/VERIFICATION.md
@@ -1,0 +1,595 @@
+# Verification Reference
+
+> Fresh verification after sub-agent completion and commit handling by mode.
+
+## Trust But Verify Principle
+
+**Sub-agent claims are reports, not evidence.**
+
+After a sub-agent reports success, the main agent MUST independently verify:
+1. All quality gates pass
+2. Plan file was actually updated
+3. Expected files exist
+
+This catches:
+- Sub-agent hallucinations
+- Partial completions reported as success
+- Quality gate regressions from parallel work
+
+---
+
+## Fresh Verification Sequence
+
+```
+VERIFICATION SEQUENCE
+=====================
+
+1. COLLECT sub-agent result JSON
+2. PARSE status and quality gate claims
+3. RUN each quality gate command fresh
+4. COMPARE fresh results to claims
+5. VERIFY plan file updates exist
+6. VERIFY files created/modified exist
+7. **VERIFY DEFINITION OF DONE - USER-FACING BEHAVIOR** (CRITICAL)
+8. DETERMINE true pass/fail status
+```
+
+### Step 7: DoD User-Facing Verification (CRITICAL)
+
+**Quality gates passing does NOT mean the phase is complete.**
+
+For each Definition of Done item, verify the actual user-facing behavior:
+
+```
+DOD VERIFICATION - Phase {PHASE_ID}
+===================================
+
+DoD items from plan:
+1. "DISCOVERED SKILLS section displays discoveries"
+2. "Tab key switches between sections"
+
+Verification:
+
+DoD #1: "DISCOVERED SKILLS section displays discoveries"
+  - LoadDiscoveries() exists: YES
+  - LoadDiscoveries() called from Init(): ???
+  - DiscoveriesLoadedMsg handled in app.go: ???
+
+  TRACING DATA FLOW:
+  → manage.go Init() returns: loadInstalled only (NOT loadDiscoveries!)
+  → DiscoveriesLoadedMsg handler: NOT FOUND in app.go
+
+  RESULT: FAIL - Function exists but is never called
+
+DoD #2: "Tab key switches between sections"
+  - Tab handler exists: YES
+  - Actually switches section: YES (verified in code)
+
+  RESULT: PASS
+
+OVERALL DOD VERIFICATION: FAIL (1 of 2 passed)
+```
+
+**THE INTEGRATION TRAP:**
+- Code existing ≠ code working
+- Tests passing ≠ feature working
+- Function defined ≠ function called
+
+**What to check:**
+- Is the function called from the appropriate entry point?
+- Is the message/result handled where it needs to be?
+- Would a user actually see the behavior if they tried it?
+
+**If DoD verification fails, treat the phase as FAILED even if quality gates pass.**
+
+### Verification Output Format
+
+```
+VERIFICATION - Phase {PHASE_ID}
+===============================
+
+Sub-agent claimed: {STATUS}
+
+Running fresh verification...
+
+Quality Gates:
+┌────────────┬─────────┬─────────────────────────────┐
+│ Check      │ Result  │ Output                      │
+├────────────┼─────────┼─────────────────────────────┤
+│ Lint       │ PASS    │ No errors                   │
+│ Format     │ PASS    │ All files formatted         │
+│ Typecheck  │ PASS    │ No type errors              │
+│ Test       │ PASS    │ 47 passed, 0 failed         │
+└────────────┴─────────┴─────────────────────────────┘
+
+Plan Updates:
+- Tasks checked: YES (4/4 items)
+- DoD checked: YES (6/6 items)
+- Status updated: YES (⬜ -> ✅)
+
+Files:
+- Created: 2/2 exist
+- Modified: 1/1 exist
+
+VERIFICATION: PASSED
+```
+
+---
+
+## Running Quality Gates
+
+### Command Execution
+
+Run each quality gate command and capture output:
+
+```python
+def run_quality_gate(name, command, timeout=120):
+    result = Bash(
+        command=command,
+        timeout=timeout * 1000,
+        description=f"Verify {name}"
+    )
+
+    return {
+        "name": name,
+        "command": command,
+        "passed": result.exit_code == 0,
+        "output": result.output[:500],  # Truncate for state file
+        "exit_code": result.exit_code
+    }
+```
+
+### Stack-Specific Commands
+
+| Stack | Lint | Format | Typecheck | Test |
+|-------|------|--------|-----------|------|
+| TypeScript/Node | `npm run lint` | `npm run format:check` | `npm run typecheck` or `npx tsc --noEmit` | `npm test` |
+| Python | `ruff check .` or `pylint src` | `black --check .` or `ruff format --check .` | `mypy .` or `pyright` | `pytest` |
+| Go | `golangci-lint run` | `test -z "$(gofmt -l .)"` | `go build ./...` | `go test ./...` |
+| Rust | `cargo clippy` | `cargo fmt --check` | `cargo check` | `cargo test` |
+
+### Handling Missing Tools
+
+If a quality gate command fails with "command not found":
+
+```
+QUALITY GATE UNAVAILABLE
+========================
+
+Check: Lint
+Command: npm run lint
+Error: Script "lint" not found in package.json
+
+Options:
+1. Skip this check (record as N/A)
+2. Halt and require tool setup
+
+Proceeding with skip...
+
+Note: Skipped checks will be marked in state file.
+```
+
+---
+
+## Verification Mismatch Handling
+
+### Sub-Agent Claimed Success, Verification Fails
+
+```
+VERIFICATION MISMATCH
+=====================
+
+Sub-agent claimed: complete
+Fresh verification: FAILED
+
+Discrepancy:
+┌────────────┬───────────────┬─────────────────┐
+│ Check      │ Sub-agent     │ Fresh Result    │
+├────────────┼───────────────┼─────────────────┤
+│ Lint       │ passed        │ FAILED (3 err)  │
+│ Test       │ 47 passed     │ FAILED (2 fail) │
+└────────────┴───────────────┴─────────────────┘
+
+This indicates a sub-agent error. Common causes:
+1. Sub-agent ran checks before final changes
+2. Sub-agent hallucinated passing results
+3. Parallel phase caused regression
+
+Action: Treating as phase FAILURE. Initiating retry...
+```
+
+### Sub-Agent Claimed Failure, Verification Passes
+
+Rare but possible (sub-agent was too pessimistic):
+
+```
+VERIFICATION UPGRADE
+====================
+
+Sub-agent claimed: failed
+Fresh verification: PASSED
+
+All quality gates pass. Possible causes:
+1. Sub-agent made fixes after reporting failure
+2. Sub-agent misread output
+3. Flaky test passed on retry
+
+Action: Accepting as SUCCESS (verification is authoritative)
+```
+
+---
+
+## Plan Update Verification
+
+### Checking Task Completion
+
+```python
+def verify_plan_updates(plan_path, phase_id, expected_tasks):
+    plan_content = Read(plan_path)
+
+    # Find phase section
+    phase_section = extract_phase_section(plan_content, phase_id)
+
+    # Count checked items
+    checked = phase_section.count("- [x]")
+    unchecked = phase_section.count("- [ ]")
+
+    return {
+        "tasks_checked": checked,
+        "tasks_unchecked": unchecked,
+        "expected": expected_tasks,
+        "all_complete": unchecked == 0 and checked >= expected_tasks
+    }
+```
+
+### Plan Update Failure
+
+If plan wasn't updated:
+
+```
+PLAN UPDATE VERIFICATION FAILED
+===============================
+
+Phase: 2A
+Expected: 4 tasks checked
+Found: 2 tasks checked, 2 unchecked
+
+Sub-agent did not complete plan updates.
+
+Action: Main agent will update plan file directly.
+```
+
+Main agent then updates the plan:
+
+```python
+# Update remaining checkboxes
+for task in unchecked_tasks:
+    Edit(
+        file_path=plan_path,
+        old_string=f"- [ ] {task}",
+        new_string=f"- [x] {task}"
+    )
+```
+
+---
+
+## File Existence Verification
+
+### Checking Created Files
+
+```python
+def verify_files_exist(files_created, files_modified):
+    missing = []
+
+    for file_path in files_created + files_modified:
+        try:
+            Read(file_path, limit=1)  # Just check existence
+        except FileNotFoundError:
+            missing.append(file_path)
+
+    return {
+        "all_exist": len(missing) == 0,
+        "missing": missing
+    }
+```
+
+### Missing Files Response
+
+```
+FILE VERIFICATION FAILED
+========================
+
+Expected files from sub-agent result:
+- src/api/auth.ts (MISSING)
+- src/api/auth.test.ts (EXISTS)
+
+Sub-agent claimed to create src/api/auth.ts but file does not exist.
+
+Action: Treating as phase FAILURE. Initiating retry...
+```
+
+---
+
+## Commit Handling by Mode
+
+### --commit=auto
+
+Auto-commit after verification passes:
+
+```
+VERIFICATION PASSED - AUTO-COMMIT
+=================================
+
+Staging files:
+  git add src/api/auth.ts src/api/auth.test.ts src/api/routes.ts
+
+Creating commit:
+  git commit -m "$(cat <<'EOF'
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+
+Commit created: a1b2c3d
+
+State file updated with commit SHA.
+```
+
+### Git Add Strategy
+
+Stage only files reported by sub-agent:
+
+```python
+def stage_files(files_created, files_modified):
+    all_files = files_created + files_modified
+
+    # Stage specific files, not "git add ."
+    if all_files:
+        file_list = " ".join(f'"{f}"' for f in all_files)
+        Bash(command=f"git add {file_list}")
+```
+
+### Commit Message Sanitization
+
+Ensure commit message is shell-safe:
+
+```python
+def sanitize_commit_message(message):
+    # Remove dangerous characters
+    dangerous = ['"', '`', '$', '!', '\\', ';', '&', '|', '>', '<', '*', '?']
+    for char in dangerous:
+        message = message.replace(char, '')
+
+    # Ensure proper line endings
+    message = message.replace('\r\n', '\n')
+
+    return message.strip()
+```
+
+### HEREDOC Commit Format
+
+Always use HEREDOC for multi-line commits:
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+EOF
+)"
+```
+
+### --commit=message-only
+
+Save message to state file and accumulate to commits.sh:
+
+```
+VERIFICATION PASSED - MESSAGE SAVED
+===================================
+
+Commit message for Phase 2A:
+
+feat(api): implement JWT token validation
+
+- Add validateToken function
+- Add token refresh endpoint
+- Add comprehensive test coverage
+
+Files to commit:
+- src/api/auth.ts (CREATE)
+- src/api/auth.test.ts (CREATE)
+- src/api/routes.ts (MODIFY)
+
+Saved to: .autobuild/phases/phase-2a.json
+Appended to: .autobuild/commits.sh
+
+User handles git operations.
+```
+
+### Commits.sh Accumulation
+
+Append each phase's commit to the script:
+
+```python
+def append_to_commits_script(phase_id, commit_message, files):
+    script_path = ".autobuild/commits.sh"
+
+    commit_block = f'''
+echo "Committing Phase {phase_id}..."
+git add {" ".join(files)}
+git commit -m "$(cat <<'EOF'
+{commit_message}
+EOF
+)"
+'''
+
+    # Append to existing script
+    with open(script_path, "a") as f:
+        f.write(commit_block)
+```
+
+### --commit=single
+
+Queue commit for final combined message:
+
+```
+VERIFICATION PASSED - COMMIT QUEUED
+===================================
+
+Phase 2A complete.
+Commit message queued for final combined commit.
+
+Queued commits: 3 of 6 phases
+
+Continuing to next phase...
+```
+
+### Combined Commit at Completion
+
+When all phases complete with --commit=single:
+
+```
+COMBINED COMMIT
+===============
+
+All 6 phases complete. Creating combined commit...
+
+Files to commit:
+- .eslintrc.json (CREATE)
+- .prettierrc (CREATE)
+- prisma/schema.prisma (CREATE)
+- src/api/auth.ts (CREATE)
+- src/api/auth.test.ts (CREATE)
+- src/components/Login.tsx (CREATE)
+- [... more files ...]
+
+Combined commit message:
+
+feat(auth): implement complete authentication system
+
+Phases completed:
+- Phase 0: Bootstrap - quality tools configuration
+- Phase 1: Setup - database schema and migrations
+- Phase 2A: Backend - authentication API endpoints
+- Phase 2B: Frontend - login and registration UI
+- Phase 2C: Tests - comprehensive test coverage
+- Phase 3: Integration - end-to-end wiring
+
+Files changed: 24
+Tests added: 47
+
+git add .
+git commit -m "$(cat <<'EOF'
+feat(auth): implement complete authentication system
+
+Phases completed:
+- Phase 0: Bootstrap - quality tools configuration
+- Phase 1: Setup - database schema and migrations
+- Phase 2A: Backend - authentication API endpoints
+- Phase 2B: Frontend - login and registration UI
+- Phase 2C: Tests - comprehensive test coverage
+- Phase 3: Integration - end-to-end wiring
+
+Files changed: 24
+Tests added: 47
+EOF
+)"
+```
+
+---
+
+## Verification Timeout Handling
+
+If verification commands hang:
+
+```
+VERIFICATION TIMEOUT
+====================
+
+Check: Test
+Command: npm test
+Timeout: 5 minutes exceeded
+
+Possible causes:
+1. Tests are hanging (infinite loop, unresolved promise)
+2. Tests are very slow
+3. External dependency is down
+
+Action: Treating as verification FAILURE.
+
+Note: The sub-agent may have completed successfully, but we cannot
+verify without passing quality gates. Initiating retry...
+```
+
+---
+
+## Parallel Phase Verification
+
+For parallel phases, verify each independently then check for conflicts:
+
+```
+PARALLEL VERIFICATION
+=====================
+
+Phase 2A:
+- Quality gates: PASS
+- Files: 2 created, 1 modified
+
+Phase 2B:
+- Quality gates: PASS
+- Files: 3 created, 0 modified
+
+Phase 2C:
+- Quality gates: PASS
+- Files: 2 created, 0 modified
+
+Conflict Check:
+- No overlapping file modifications
+- All tests still pass together
+
+PARALLEL BATCH: VERIFIED
+```
+
+### Detecting Parallel Conflicts
+
+```python
+def check_parallel_conflicts(results):
+    all_files = {}
+
+    for phase_id, result in results.items():
+        modified = result["files"]["modified"]
+        for file in modified:
+            if file in all_files:
+                return {
+                    "conflict": True,
+                    "file": file,
+                    "phases": [all_files[file], phase_id]
+                }
+            all_files[file] = phase_id
+
+    return {"conflict": False}
+```
+
+### Conflict Response
+
+```
+PARALLEL CONFLICT DETECTED
+==========================
+
+File: src/api/routes.ts
+Modified by: Phase 2A AND Phase 2B
+
+Both phases modified the same file. This may cause merge conflicts.
+
+Resolution options:
+1. Manual merge required
+2. Re-run phases sequentially
+3. Abort and fix plan
+
+AUTOBUILD HALTED - Parallel conflict
+```

--- a/.codex/skills/modern-python
+++ b/.codex/skills/modern-python
@@ -1,0 +1,1 @@
+/Users/adamcobb/.agents/skulto/repositories/trailofbits/skills/plugins/modern-python/skills/modern-python

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ skulto/
 │   ├── detect/              # AI tool detection on system (command/dir checks)
 │   ├── discovery/           # Skill discovery and ingestion from local dirs
 │   ├── embedding/           # OpenAI embedding provider abstraction
-│   ├── favorites/           # File-based favorites persistence (~/.skulto/favorites.json)
+│   ├── favorites/           # File-based favorites persistence (~/.agents/skulto/favorites.json)
 │   ├── installer/           # Skill installation via symlinks (33 platforms)
 │   ├── llm/                 # LLM provider abstraction (Anthropic, OpenAI, OpenRouter)
 │   ├── log/                 # Structured logging
@@ -45,7 +45,7 @@ skulto/
 │   ├── scraper/             # GitHub scraping (git clone based, shallow clones)
 │   ├── search/              # Hybrid search service (FTS5 + semantic)
 │   ├── security/            # Security scanner (prompt injection detection)
-│   ├── skillgen/            # Local skill scanning (~/.skulto/skills, ./.skulto/skills)
+│   ├── skillgen/            # Local skill scanning (~/.agents/skulto/skills, ./.skulto/skills)
 │   ├── telemetry/           # PostHog analytics (opt-in events defined in events.go)
 │   ├── testutil/            # Test utilities and helpers
 │   ├── tui/                 # Bubble Tea TUI application
@@ -165,15 +165,15 @@ Downloads Go modules, runs `go mod tidy`, and installs golangci-lint to `./bin/`
 
 ### Data Directory
 
-Skulto stores data in `~/.skulto/`:
+Skulto stores data in `~/.agents/skulto/`:
 
 | Path | Purpose |
 |------|---------|
-| `~/.skulto/skulto.db` | SQLite database |
-| `~/.skulto/skulto.log` | Logfile |
-| `~/.skulto/repositories/{owner}/{repo}/` | Cloned git repositories |
-| `~/.skulto/favorites.json` | Favorite skills (persists across DB resets) |
-| `~/.skulto/skills/` | User's local skills directory |
+| `~/.agents/skulto/skulto.db` | SQLite database |
+| `~/.agents/skulto/skulto.log` | Logfile |
+| `~/.agents/skulto/repositories/{owner}/{repo}/` | Cloned git repositories |
+| `~/.agents/skulto/favorites.json` | Favorite skills (persists across DB resets) |
+| `~/.agents/skulto/skills/` | User's local skills directory |
 
 ## Common Tasks
 

--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,14 @@ dev:
 ## test: Run all tests including integration tests that require network access
 test:
 	@echo "Running tests with coverage..."
-	$(GO) test -v -coverprofile=coverage.out ./internal/...
+	SKULTO_SKIP_MIGRATION=1 $(GO) test -v -coverprofile=coverage.out ./internal/...
 	$(GO) tool cover -html=coverage.out -o coverage.html
 	@echo "Coverage report: coverage.html"
 
 ## test-race: Run tests with race detector (requires CGO, excludes integration tests)
 test-race:
 	@echo "Running tests with race detector..."
-	CGO_ENABLED=1 $(GO) test -v -race ./internal/...
+	SKULTO_SKIP_MIGRATION=1 CGO_ENABLED=1 $(GO) test -v -race ./internal/...
 	@echo "✅ Tests passed"
 
 ## lint: Run linters

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ skulto update --scan-all
 
 #### `skulto favorites`
 
-Manage your favorite skills. Favorites persist across database resets and are stored separately in `~/.skulto/favorites.json`.
+Manage your favorite skills. Favorites persist across database resets and are stored separately in `~/.agents/skulto/favorites.json`.
 
 ```bash
 # Add a skill to favorites
@@ -379,14 +379,14 @@ The MCP server also exposes resources for direct skill access:
 
 ### Database Location
 
-Skulto stores data in `~/.skulto/`:
+Skulto stores data in `~/.agents/skulto/`:
 
 | Path | Purpose |
 | --- | --- |
-| `~/.skulto/skulto.db` | SQLite database |
-| `~/.skulto/skulto.log` | Logfile |
-| `~/.skulto/repositories/` | Cloned git repositories |
-| `~/.skulto/favorites.json` | Favorite skills (persists across DB resets) |
+| `~/.agents/skulto/skulto.db` | SQLite database |
+| `~/.agents/skulto/skulto.log` | Logfile |
+| `~/.agents/skulto/repositories/` | Cloned git repositories |
+| `~/.agents/skulto/favorites.json` | Favorite skills (persists across DB resets) |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ## What is Skulto?
 
-Skulto is a cross-platform CLI tool for managing AI coding assistant skills across 30+ platforms. It provides:
+Skulto is a cross-platform CLI tool for managing AI coding assistant skills across 33 platforms. It provides:
 
 1. **Multi-platform installation** - Install skills to Claude Code, Cursor, Windsurf, Copilot, Codex, Cline, Roo Code, Gemini CLI, Kiro CLI, and 25+ more
 2. **Repository management** - Add, sync, and remove skill repositories
@@ -37,7 +37,7 @@ Skulto is a cross-platform CLI tool for managing AI coding assistant skills acro
 
 ![Skill Creation](assets/skill-create-small.gif)
 
-- **30+ platform support** - Claude Code, Cursor, Windsurf, GitHub Copilot, OpenAI Codex, OpenCode, Cline, Roo Code, Gemini CLI, Kiro CLI, Amp, Continue, Goose, Junie, Qwen Code, Trae, and more
+- **33 platform support** - Claude Code, Cursor, Windsurf, GitHub Copilot, OpenAI Codex, OpenCode, Cline, Roo Code, Gemini CLI, Kiro CLI, Amp, Continue, Goose, Junie, Qwen Code, Trae, and more
 - **Platform detection** - Detects installed AI tools and surfaces them in platform choosers
 - **Offline-first** - Works without internet after initial sync
 - **Fast search** - FTS5-powered full-text search with BM25 ranking (~50ms latency)
@@ -120,6 +120,95 @@ On first launch, Skulto walks you through onboarding:
 2. **Skill selection** - Curated starter skills from Asteroid Belt (superplan, superbuild, teach, agentsmd-generator, and more)
 3. **Location chooser** - Pick global or project scope per platform, with your previous selections pre-filled
 
+## Skill Management for Teams
+
+Skulto works like a package manager for AI agent skills. Use `skulto.json` to define the skills your project needs, then `skulto sync` to install them — so every developer and CI environment has the same skill setup.
+
+### The Workflow
+
+```bash
+# 1. Install skills into your project
+skulto install superplan
+skulto install teach
+
+# 2. Save project skills to a manifest
+skulto save
+
+# 3. Commit skulto.json to your repo
+git add skulto.json
+git commit -m "add skulto skill manifest"
+
+# 4. Teammates (or CI) sync from the manifest
+skulto sync
+```
+
+### `skulto.json`
+
+The manifest tracks which skills your project depends on and where they come from:
+
+```json
+{
+  "version": 1,
+  "skills": {
+    "superplan": "asteroid-belt/skills",
+    "teach": "asteroid-belt/skills",
+    "resume-ats-optimizer": "paramchoudhary/resumeskills"
+  }
+}
+```
+
+Each entry maps a skill slug to its source repository (`owner/repo`). When a teammate runs `skulto sync`, Skulto clones any missing repositories, resolves the skills, and installs them to the selected platforms.
+
+### `skulto save`
+
+Captures your current project-scope installations into `skulto.json`:
+
+```bash
+$ skulto save
+
+SAVED to skulto.json
+
+  teach               asteroid-belt/skills
+  superplan           asteroid-belt/skills
+
+2 skill(s) saved
+```
+
+Only project-scope installations are saved — global installs are personal and not shared via the manifest.
+
+### `skulto sync`
+
+Reads `skulto.json` and installs any missing skills:
+
+```bash
+$ skulto sync
+
+SYNCING from skulto.json (2 skills)
+────────────────────────────────────────────────
+Done! Installed: 2, Skipped: 0
+```
+
+On sync, Skulto:
+1. Adds any source repositories not already in the local database
+2. Resolves each skill by slug
+3. Prompts for platform and scope selection (or uses detected defaults with `-y`)
+4. Skips skills that are already installed at the selected locations
+
+### `skulto check`
+
+Shows all installed skills and where they're installed:
+
+```bash
+$ skulto check
+
+SKILL                  INSTALLED LOCATIONS
+─────────────────────────────────────────────────────────────
+superplan              claude (global), codex (global + project)
+teach                  claude (global + project)
+
+2 skill(s) installed
+```
+
 ## Usage
 
 ### TUI Mode (Default)
@@ -194,6 +283,10 @@ Skulto provides CLI subcommands for scripting and automation:
 | --- | --- |
 | `skulto` | Launch the interactive TUI |
 | `skulto install <slug or repo>` | Install skills by slug or from a repository URL |
+| `skulto uninstall <slug>` | Uninstall a skill from selected platforms |
+| `skulto save` | Save project-scope installations to `skulto.json` |
+| `skulto sync` | Install all skills from `skulto.json` manifest |
+| `skulto check` | List all installed skills and their locations |
 | `skulto add <repo>` | Add a skill repository and sync its skills |
 | `skulto list` | List all configured source repositories |
 | `skulto pull` | Pull/sync all repositories and reconcile installed skills |
@@ -361,7 +454,7 @@ Add to your Claude Code settings (`.claude.json`):
 | `skulto_browse_tags` | List available tags by category (language, framework, tool, concept, domain) |
 | `skulto_get_stats` | Get database statistics (total skills, tags, sources) |
 | `skulto_get_recent` | Get recently viewed skills |
-| `skulto_install` | Install a skill to any supported platform (30+ platforms, global or project scope) |
+| `skulto_install` | Install a skill to any supported platform (33 platforms, global or project scope) |
 | `skulto_uninstall` | Uninstall a skill from specified platforms |
 | `skulto_favorite` | Add or remove a skill from favorites |
 | `skulto_get_favorites` | Get favorite skills |
@@ -377,16 +470,19 @@ The MCP server also exposes resources for direct skill access:
 | `skulto://skill/{slug}` | Full markdown content of a skill |
 | `skulto://skill/{slug}/metadata` | JSON metadata including tags, source, and stats |
 
-### Database Location
+### Data Directory
 
-Skulto stores data in `~/.agents/skulto/`:
+Skulto stores data in `~/.agents/skulto/`, coexisting with other agent tooling under the shared `~/.agents/` namespace:
 
 | Path | Purpose |
 | --- | --- |
 | `~/.agents/skulto/skulto.db` | SQLite database |
 | `~/.agents/skulto/skulto.log` | Logfile |
 | `~/.agents/skulto/repositories/` | Cloned git repositories |
+| `~/.agents/skulto/skills/` | User's local skills directory |
 | `~/.agents/skulto/favorites.json` | Favorite skills (persists across DB resets) |
+
+> **Upgrading from a previous version?** If you have an existing `~/.skulto/` directory, Skulto automatically migrates it to `~/.agents/skulto/` on first launch — including database records and installed skill symlinks. No manual steps required.
 
 ## Development
 

--- a/context/architecture.md
+++ b/context/architecture.md
@@ -127,7 +127,7 @@ The scraper manages GitHub repositories using shallow git clones.
 | `parser.go` | `SkillParser` - SKILL.md/CLAUDE.md parsing with frontmatter |
 
 **Repository caching:**
-- Repos cloned to `~/.skulto/repositories/{owner}/{repo}/`
+- Repos cloned to `~/.agents/skulto/repositories/{owner}/{repo}/`
 - Shallow clones (depth=1) for efficiency
 - `RecentUpdateTTL` (60s) prevents redundant fetches
 - Per-repo mutex locks for concurrent access
@@ -423,7 +423,7 @@ func (s *Server) registerResources() {
 Skills are installed as symlinks pointing to cloned repository files:
 
 ```
-~/.claude/skills/superplan -> ~/.skulto/repositories/asteroid-belt/skills/skills/superplan/
+~/.claude/skills/superplan -> ~/.agents/skulto/repositories/asteroid-belt/skills/skills/superplan/
 ```
 
 **Benefits:**

--- a/context/database.md
+++ b/context/database.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Skulto uses SQLite with GORM ORM and FTS5 for full-text search. The database is stored at `~/.skulto/skulto.db`.
+Skulto uses SQLite with GORM ORM and FTS5 for full-text search. The database is stored at `~/.agents/skulto/skulto.db`.
 
 ## Database Configuration
 

--- a/context/platforms.md
+++ b/context/platforms.md
@@ -167,8 +167,8 @@ For skill `superplan` on Claude:
 
 | Scope | Full Path |
 |-------|-----------|
-| Global | `~/.claude/skills/superplan` -> `~/.skulto/repositories/asteroid-belt/skills/skills/superplan/` |
-| Project | `./.claude/skills/superplan` -> `~/.skulto/repositories/asteroid-belt/skills/skills/superplan/` |
+| Global | `~/.claude/skills/superplan` -> `~/.agents/skulto/repositories/asteroid-belt/skills/skills/superplan/` |
+| Project | `./.claude/skills/superplan` -> `~/.agents/skulto/repositories/asteroid-belt/skills/skills/superplan/` |
 
 ## InstallLocation
 
@@ -219,7 +219,7 @@ func (i *Installer) createSymlink(skillDir, targetPath string) error {
 For repository skills:
 ```go
 sourceDir = filepath.Join(
-    cfg.BaseDir,                    // ~/.skulto
+    cfg.BaseDir,                    // ~/.agents/skulto
     "repositories",
     source.Owner,                   // asteroid-belt
     source.Repo,                    // skills
@@ -229,7 +229,7 @@ sourceDir = filepath.Join(
 
 For local skills:
 ```go
-sourceDir = filepath.Dir(skill.FilePath)  // ~/.skulto/skills/my-skill
+sourceDir = filepath.Dir(skill.FilePath)  // ~/.agents/skulto/skills/my-skill
 ```
 
 ## Database Tracking

--- a/docs/adr/0001-symlink-based-skill-installation.md
+++ b/docs/adr/0001-symlink-based-skill-installation.md
@@ -11,7 +11,7 @@ Two approaches were considered: copying skill files to each target directory, or
 
 ## Decision
 
-Skills are installed as symlinks. The installer creates a symbolic link from the platform's skills directory to the skill's directory inside the cloned repository at `~/.skulto/repositories/{owner}/{repo}/`.
+Skills are installed as symlinks. The installer creates a symbolic link from the platform's skills directory to the skill's directory inside the cloned repository at `~/.agents/skulto/repositories/{owner}/{repo}/`.
 
 ## Consequences
 

--- a/docs/adr/0004-environment-variable-only-configuration.md
+++ b/docs/adr/0004-environment-variable-only-configuration.md
@@ -19,7 +19,7 @@ Key environment variables:
 - `ANTHROPIC_API_KEY` - LLM provider for skill generation
 - `SKULTO_TELEMETRY_TRACKING_ENABLED` - Telemetry opt-out
 
-The base data directory (`~/.skulto/`) is hardcoded rather than configurable.
+The base data directory (`~/.agents/skulto/`) is hardcoded rather than configurable.
 
 ## Consequences
 
@@ -52,7 +52,7 @@ The base data directory (`~/.skulto/`) is hardcoded rather than configurable.
 |-------------|-----------|
 | Code | `internal/config/config.go:82` - `Load()` reads exclusively from `os.Getenv()` |
 | Code comment | `AGENTS.md:33` - "Configuration (env vars only, no config file)" |
-| Code | `internal/config/paths.go` - hardcoded `~/.skulto` base directory |
+| Code | `internal/config/paths.go` - hardcoded `~/.agents/skulto` base directory |
 
 ## Related
 

--- a/docs/adr/0005-git-clone-over-github-api.md
+++ b/docs/adr/0005-git-clone-over-github-api.md
@@ -11,7 +11,7 @@ The GitHub API has rate limits (60 requests/hour unauthenticated, 5000/hour with
 
 ## Decision
 
-Use git clone (via the go-git library) with shallow clones to fetch repositories locally. Cloned repositories are stored at `~/.skulto/repositories/{owner}/{repo}/`. The `UseGitClone` config flag defaults to `true`.
+Use git clone (via the go-git library) with shallow clones to fetch repositories locally. Cloned repositories are stored at `~/.agents/skulto/repositories/{owner}/{repo}/`. The `UseGitClone` config flag defaults to `true`.
 
 The scraper retains a `Client` interface that abstracts the data source, allowing fallback to the GitHub API if needed.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,15 +54,15 @@ Skulto uses environment variables exclusively - there is no config file.
 | `OPENAI_API_KEY` | No | Enables semantic search with OpenAI embeddings | None (FTS5 only) |
 | `SKULTO_TELEMETRY_TRACKING_ENABLED` | No | Set to `false` to disable anonymous telemetry | `true` |
 
-All data is stored in `~/.skulto/`:
+All data is stored in `~/.agents/skulto/`:
 
 | Path | Purpose |
 |------|---------|
-| `~/.skulto/skulto.db` | SQLite database |
-| `~/.skulto/skulto.log` | Log file |
-| `~/.skulto/repositories/` | Cloned git repositories |
-| `~/.skulto/favorites.json` | Favorite skills (persists across DB resets) |
-| `~/.skulto/skills/` | User's local skills directory |
+| `~/.agents/skulto/skulto.db` | SQLite database |
+| `~/.agents/skulto/skulto.log` | Log file |
+| `~/.agents/skulto/repositories/` | Cloned git repositories |
+| `~/.agents/skulto/favorites.json` | Favorite skills (persists across DB resets) |
+| `~/.agents/skulto/skills/` | User's local skills directory |
 
 ## Running Locally
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -16,7 +16,7 @@ are omitted unless they have a project-specific meaning.
 | Threat Level | Security classification assigned by the scanner: NONE, LOW, MEDIUM, HIGH, or CRITICAL. Determines whether a skill is quarantined. | `internal/models/security.go`, `internal/security/` |
 | Quarantine | A security status that blocks a skill from being installed. Applied when scanning detects prompt injection patterns above a confidence threshold. | `internal/security/scanner.go` |
 | Discovered Skill | A non-symlinked skill directory found in a platform's skill folder that is not managed by Skulto. The discovery system notifies users about these. | `internal/models/discovered_skill.go`, `internal/discovery/` |
-| Ingestion | The process of importing a discovered (unmanaged) skill into Skulto management by copying it to `~/.skulto/skills/` and replacing the original with a symlink. | `internal/discovery/ingestion.go` |
+| Ingestion | The process of importing a discovered (unmanaged) skill into Skulto management by copying it to `~/.agents/skulto/skills/` and replacing the original with a symlink. | `internal/discovery/ingestion.go` |
 | Seed | A pre-configured source repository that ships with Skulto (e.g., `asteroid-belt/skills`). Seeds are scraped during onboarding. | `internal/scraper/seeds.go` |
 | Onboarding | The first-run experience where users select AI platforms and starter skills. Tracked via `UserState.OnboardingStatus`. | `internal/tui/views/onboarding_*.go` |
 | FTS5 | SQLite's Full-Text Search extension version 5, used for BM25-ranked skill search. Skulto maintains a virtual table (`skills_fts`) synchronized via triggers. | `internal/db/db.go`, `internal/db/skills.go` |
@@ -25,7 +25,7 @@ are omitted unless they have a project-specific meaning.
 | MCP | Model Context Protocol - a JSON-RPC 2.0 protocol over stdio that enables AI assistants like Claude Code to interact with external tools. Skulto's MCP server exposes search, install, and management capabilities. | `internal/mcp/`, `cmd/skulto-mcp/` |
 | Auxiliary File | A non-markdown file (script, reference, asset) bundled with a skill. These are tracked separately and scanned independently for security threats. | `internal/models/skill.go` |
 | Tag | A categorization label applied to skills. Tags have categories (language, framework, tool, concept, domain) and are used for browsing and filtering. | `internal/models/tag.go`, `internal/db/tags.go` |
-| Favorites | User-bookmarked skills persisted in `~/.skulto/favorites.json`. Favorites survive database resets because they are stored outside the SQLite database. | `internal/favorites/favorites.go` |
+| Favorites | User-bookmarked skills persisted in `~/.agents/skulto/favorites.json`. Favorites survive database resets because they are stored outside the SQLite database. | `internal/favorites/favorites.go` |
 
 ## Acronyms
 

--- a/docs/skulto-add-mcp-tool-plan.md
+++ b/docs/skulto-add-mcp-tool-plan.md
@@ -1,0 +1,292 @@
+# Feature Plan: `skulto_add` MCP Tool
+
+## Summary
+
+Add a new `skulto_add` MCP tool that adds a skill repository by URL, reusing the same logic as `skulto add` CLI and the TUI's 'a' button. The tool parses the URL, checks for duplicates, inserts the source into the database, scrapes all skills, and returns the list of scraped skills so the user can immediately install any of them.
+
+## Requirements
+
+- **MVP**: Always scrape immediately after adding (no `--no-sync` equivalent)
+- **Duplicates**: Reject if source already exists (matches CLI behavior)
+- **Scope**: Only the MCP tool — no changes to CLI or TUI
+- **URL formats**: `owner/repo`, `https://github.com/owner/repo`, `.git` variants, SSH variants
+- **Response**: Include list of scraped skill names/slugs so user can install immediately
+
+## Tech Stack
+
+- **Language**: Go 1.25+
+- **MCP Library**: `mcp-go` (`github.com/mark3labs/mcp-go`)
+- **Database**: SQLite via `internal/db`
+- **Scraper**: `internal/scraper`
+
+## Architecture
+
+The new tool follows the exact pattern of all existing MCP tools:
+
+```
+tools.go:  addTool() → defines skulto_add with "url" param
+handlers.go: handleAdd() → parses URL, checks dups, upserts, scrapes, lists skills
+server.go: registerTools() → s.server.AddTool(addTool(), s.handleAdd)
+```
+
+### Data Flow
+
+```
+MCP Client calls skulto_add(url: "owner/repo")
+    ↓
+handleAdd():
+  1. Parse URL via scraper.ParseRepositoryURL()
+  2. Check for existing source via s.db.GetSource()
+  3. Insert source via s.db.UpsertSource()
+  4. Create scraper with s.cfg GitHub config
+  5. ScrapeRepository() with 5-minute timeout
+  6. Query s.db.GetSkillsBySourceID() to get scraped skills
+  7. Return AddResult JSON with skills list
+    ↓
+MCP Client receives:
+{
+  "success": true,
+  "message": "Repository 'owner/repo' added with 3 skills",
+  "source": {"owner": "owner", "repo": "repo", "url": "..."},
+  "skills_found": 3,
+  "skills": [
+    {"slug": "react-hooks", "title": "React Hooks Best Practices"},
+    {"slug": "go-patterns", "title": "Go Design Patterns"},
+    {"slug": "tdd-guide", "title": "Test-Driven Development Guide"}
+  ]
+}
+```
+
+### Response Types
+
+```go
+// AddResult represents the result of adding a repository.
+type AddResult struct {
+    Success     bool              `json:"success"`
+    Message     string            `json:"message"`
+    Source      *SourceResponse   `json:"source,omitempty"`
+    SkillsFound int               `json:"skills_found"`
+    Skills      []AddSkillResult  `json:"skills,omitempty"`
+}
+
+// AddSkillResult is a minimal skill reference returned after adding a repo.
+type AddSkillResult struct {
+    Slug  string `json:"slug"`
+    Title string `json:"title"`
+}
+```
+
+## Implementation Phases
+
+| Phase | Name | Depends On | Parallel With | Estimate | Status |
+|-------|------|------------|---------------|----------|--------|
+| 1 | Add tool definition + handler + registration | None | - | 3 | ✅ |
+| 2 | Add tests | Phase 1 | - | 3 | ✅ |
+
+**Total estimate: 5 points** (some tasks overlap)
+
+---
+
+## Phase 1: Tool Definition, Handler & Registration (Est: 3)
+
+### Task 1.1: Add tool definition — `internal/mcp/tools.go` (MODIFY)
+
+Add at end of file:
+
+```go
+// addTool returns the skulto_add tool definition.
+func addTool() mcp.Tool {
+	return mcp.NewTool("skulto_add",
+		mcp.WithDescription("Add a skill repository and sync its skills. Supports multiple URL formats: owner/repo, https://github.com/owner/repo, https://github.com/owner/repo.git, git@github.com:owner/repo.git"),
+		mcp.WithString("url",
+			mcp.Required(),
+			mcp.Description("Repository URL in any supported format (e.g., 'owner/repo' or full GitHub URL)"),
+		),
+	)
+}
+```
+
+### Task 1.2: Add response types and handler — `internal/mcp/handlers.go` (MODIFY)
+
+Add `AddResult`, `AddSkillResult` structs and `handleAdd` method. The handler reuses the same logic as `cli/add.go:runAdd()` and `tui/app.go:addSourceCmd()`:
+
+```go
+// AddResult represents the result of adding a repository.
+type AddResult struct {
+	Success     bool             `json:"success"`
+	Message     string           `json:"message"`
+	Source      *SourceResponse  `json:"source,omitempty"`
+	SkillsFound int              `json:"skills_found"`
+	Skills      []AddSkillResult `json:"skills,omitempty"`
+}
+
+// AddSkillResult is a minimal skill reference returned after adding a repo.
+type AddSkillResult struct {
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+}
+
+// handleAdd handles the skulto_add tool.
+func (s *Server) handleAdd(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	url, ok := req.Params.Arguments["url"].(string)
+	if !ok || url == "" {
+		return mcp.NewToolResultError("url parameter is required"), nil
+	}
+
+	// Parse and validate the repository URL
+	source, err := scraper.ParseRepositoryURL(url)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid repository URL: %v", err)), nil
+	}
+
+	// Check if source already exists
+	existing, err := s.db.GetSource(source.ID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to check existing source: %v", err)), nil
+	}
+	if existing != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("repository %s already exists", source.ID)), nil
+	}
+
+	// Add source to database
+	if err := s.db.UpsertSource(source); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to add source: %v", err)), nil
+	}
+
+	// Create scraper and sync
+	scraperCfg := scraper.ScraperConfig{
+		Token:        s.cfg.GitHub.Token,
+		DataDir:      s.cfg.BaseDir,
+		RepoCacheTTL: s.cfg.GitHub.RepoCacheTTL,
+		UseGitClone:  s.cfg.GitHub.UseGitClone,
+	}
+	sc := scraper.NewScraperWithConfig(scraperCfg, s.db)
+
+	syncCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
+
+	result, err := sc.ScrapeRepository(syncCtx, source.Owner, source.Repo)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to sync %s: %v", source.ID, err)), nil
+	}
+
+	// Fetch the scraped skills to include in response
+	skills, err := s.db.GetSkillsBySourceID(source.ID)
+	var skillResults []AddSkillResult
+	if err == nil {
+		skillResults = make([]AddSkillResult, 0, len(skills))
+		for _, skill := range skills {
+			skillResults = append(skillResults, AddSkillResult{
+				Slug:  skill.Slug,
+				Title: skill.Title,
+			})
+		}
+	}
+
+	addResult := AddResult{
+		Success: true,
+		Message: fmt.Sprintf("Repository '%s/%s' added with %d skills", source.Owner, source.Repo, result.SkillsNew),
+		Source: &SourceResponse{
+			Owner: source.Owner,
+			Repo:  source.Repo,
+			URL:   source.URL,
+		},
+		SkillsFound: result.SkillsNew,
+		Skills:      skillResults,
+	}
+
+	data, _ := json.Marshal(addResult)
+	return mcp.NewToolResultText(string(data)), nil
+}
+```
+
+New import needed: `"github.com/asteroid-belt/skulto/internal/scraper"`
+
+### Task 1.3: Register tool — `internal/mcp/server.go:registerTools()` (MODIFY)
+
+Add to `registerTools()`:
+
+```go
+// Repository management
+s.server.AddTool(addTool(), s.handleAdd)
+```
+
+### Definition of Done — Phase 1
+- [x] Code compiles (`go build ./...`)
+- [x] Code passes linter
+- [x] Code passes formatter (`gofmt`)
+- [x] No new warnings introduced
+- [x] **CHECKPOINT: Phase 1 complete**
+
+---
+
+## Phase 2: Tests (Est: 3)
+
+### Task 2.1: Add handler tests — `internal/mcp/handlers_test.go` (MODIFY)
+
+Tests to add, following the existing test patterns (using `setupTestDB`, `seedTestSkills`, direct handler calls):
+
+```go
+func TestHandleAdd(t *testing.T) {
+	// Test 1: Missing url parameter → error
+	// Test 2: Empty url parameter → error
+	// Test 3: Invalid url format → error
+	// Test 4: Duplicate source → error "already exists"
+	// Test 5: Valid URL adds source to database (mock-free: just verify DB state)
+}
+```
+
+**Note**: The scraper calls GitHub API, so full integration tests would require network access or mocking. The tests should focus on:
+- Parameter validation (missing/empty/invalid URL)
+- Duplicate detection (insert a source first, then try to add the same one)
+- URL parsing validation (various formats)
+
+For the scrape step, we accept that the handler will return an error about GitHub access in test environments — this matches how the TUI and CLI handle it (no scraper mocking exists in the codebase).
+
+### Definition of Done — Phase 2
+- [x] All new tests pass (`go test ./internal/mcp/...`)
+- [x] All existing tests still pass
+- [x] Code passes linter and formatter
+- [x] **CHECKPOINT: Complete**
+
+---
+
+## Conventional Commit Message
+
+```
+feat(mcp): add skulto_add tool for adding skill repositories
+
+Adds a new MCP tool that allows adding skill repositories via the MCP
+protocol, reusing the same URL parsing and scraping logic as the CLI
+`skulto add` command and TUI 'a' button. Returns list of scraped skills
+so the user can immediately install them.
+
+Files changed:
+- internal/mcp/tools.go (MODIFY)
+- internal/mcp/handlers.go (MODIFY)
+- internal/mcp/server.go (MODIFY)
+- internal/mcp/handlers_test.go (MODIFY)
+```
+
+---
+
+## Execution Options
+
+```
+PLAN COMPLETE: docs/skulto-add-mcp-tool-plan.md
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EXECUTION OPTIONS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Option 1: Execute Now (This Session)
+  Run `/superbuild docs/skulto-add-mcp-tool-plan.md`
+
+Option 2: Execute in Fresh Session
+  Start new session and run `/superbuild docs/skulto-add-mcp-tool-plan.md`
+
+Option 3: Review First
+  Read through the plan, suggest modifications, then execute
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Which option would you like?
+```

--- a/docs/superpowers/specs/2026-03-30-migrate-skulto-to-agents-dir-design.md
+++ b/docs/superpowers/specs/2026-03-30-migrate-skulto-to-agents-dir-design.md
@@ -1,0 +1,163 @@
+# Design: Migrate ~/.skulto to ~/.agents/skulto
+
+**Date:** 2026-03-30
+**Status:** Draft
+**Scope:** Global home directory only. Project-local `./.skulto/skills` is unchanged.
+
+## Motivation
+
+Move Skulto's data directory from `~/.skulto` to `~/.agents/skulto` to coexist under the `~/.agents/` namespace alongside other agent tooling (e.g., vercel-labs/skills uses `~/.agents/skills/`). This aligns Skulto with the emerging convention for agent data directories.
+
+## Design
+
+### 1. Change DefaultBaseDir
+
+`internal/config/paths.go:DefaultBaseDir()` changes from `~/.skulto` to `~/.agents/skulto`. This is the single source of truth — all other paths derive from `cfg.BaseDir`.
+
+### 2. Auto-Migration on Launch
+
+A new `migrateBaseDir()` function runs in `config.Load()` before `ensureDirectories()`. It performs a deterministic sequence of filesystem checks and actions.
+
+#### Migration Flow
+
+```
+migrateBaseDir()
+  1. Does ~/.skulto exist?
+     → no: done (fresh install)
+     → is symlink: skip
+     → yes, is real dir:
+  2. Does ~/.agents/ exist?
+     → no: create it (os.MkdirAll, 0755)
+  3. Does ~/.agents/skulto/ exist?
+     → no: create it (os.MkdirAll, 0755)
+  4. Does ~/.agents/skulto/ have contents?
+     → yes: remove ~/.skulto, done
+     → no:
+        a. copy all contents from ~/.skulto → ~/.agents/skulto
+        b. verify integrity (file count + total sizes match)
+        c. remove ~/.skulto
+        d. log.Info("Migrated ~/.skulto → ~/.agents/skulto")
+```
+
+**Why copy instead of rename?** `os.Rename` is attempted first (atomic, instant on same filesystem). If it fails (cross-device), fall back to recursive copy with integrity verification.
+
+#### Error Handling
+
+| Step | Failure | Behavior |
+|------|---------|----------|
+| 2/3 (mkdir) | Permission denied | Return error, fall back to `~/.skulto` for this session. Retries next launch. |
+| 4a (copy) | Partial copy | Leave both dirs. Next launch sees contents in `~/.agents/skulto` → removes `~/.skulto`. |
+| 4b (verify) | Mismatch | Don't remove `~/.skulto`. Log error. Retries next launch. |
+| 4c (remove) | Permission denied | Non-fatal warning. `~/.agents/skulto` is already active. Stale `~/.skulto` is harmless. |
+
+### 3. Database Path Migration
+
+The SQLite database stores absolute paths for local skills that reference `~/.skulto`:
+
+```
+skills.file_path: /Users/x/.skulto/skills/my-skill/skill.md
+```
+
+After the filesystem move, run:
+
+```sql
+UPDATE skills
+SET file_path = REPLACE(file_path, '/.skulto/', '/.agents/skulto/')
+WHERE file_path LIKE '%/.skulto/%';
+```
+
+This runs as part of `migrateBaseDir()`, after the filesystem move succeeds and before returning. The DB file has already been moved as part of the directory, so it's opened from its new location.
+
+**Scope:** Only the `skills.file_path` column contains `~/.skulto` references. All other path columns (`skill_installations.symlink_path`, `discovered_skills.path`, etc.) store paths to platform directories (`~/.claude/skills/`, `~/.cursor/skills/`) which are unaffected.
+
+### 4. Hardcoded Path Updates
+
+Six Go files bypass `cfg.BaseDir` and hardcode `.skulto` in path construction. Only the **global home directory** references change — project-local `./.skulto/skills` paths are unchanged.
+
+| File | Line(s) | What Changes |
+|------|---------|--------------|
+| `internal/config/paths.go` | 34, 36 | `DefaultBaseDir()`: `.skulto` → `.agents/skulto` |
+| `internal/vector/chromem.go` | 32 | Fallback: `".skulto", "vectors"` → `".agents", "skulto", "vectors"` |
+| `internal/skillgen/executor.go` | 444 | Home skills dir: `".skulto", "skills"` → `".agents", "skulto", "skills"` |
+| `internal/discovery/scanner.go` | 116-117 | Symlink target matching: add `.agents/skulto` patterns alongside existing `.skulto` patterns |
+| `internal/discovery/ingestion.go` | 138, 149 | Fallback paths (these are cwd-relative, **no change** — they use `.skulto/skills` for local project context) |
+| `internal/cli/ingest.go` | 168, 249 | These are cwd-relative (`.skulto/skills`), **no change** |
+
+**Note on scanner.go:** The `categorizeByTarget()` function string-matches symlink targets to determine management source. It must recognize both old (`/.skulto/`) and new (`/.agents/skulto/`) paths to correctly categorize skills installed before and after migration.
+
+### 5. UI/Display String Updates
+
+| File | Line(s) | Change |
+|------|---------|--------|
+| `internal/tui/components/quick_skill_dialog.go` | 656, 744, 958 | `~/.skulto/skills/` → `~/.agents/skulto/skills/` |
+| `internal/tui/components/save_options_dialog.go` | 57 | `.skulto/skills/` → `.agents/skulto/skills/` (this is a generic description, update to match new path) |
+
+### 6. Documentation/Comment Updates
+
+Update `~/.skulto` references in:
+
+- `AGENTS.md` — data directory table
+- `README.md` — favorites path, directory descriptions
+- `context/database.md` — DB path reference
+- `context/platforms.md` — source path examples
+- `docs/getting-started.md` — setup instructions
+- `docs/glossary.md` — if referenced
+- `docs/adr/0001-symlink-based-skill-installation.md` — path examples
+- `docs/adr/0004-environment-variable-only-configuration.md` — base dir reference
+- `docs/adr/0005-git-clone-over-github-api.md` — clone dir reference
+- Inline comments in `internal/tui/app.go`, `internal/installer/installer.go`, `internal/installer/paths.go`, `internal/scraper/scraper.go`, `internal/config/config.go`, `internal/tui/views/reset.go`
+
+### 7. Test Updates
+
+| File | Change |
+|------|--------|
+| `internal/config/migrate_test.go` | **New file.** Test all migration branches: fresh install, already migrated, successful move, cross-device fallback, partial failure recovery, DB path update. |
+| `internal/installer/installer_test.go` | Update `.skulto` in test helper `testConfig()` |
+| `internal/discovery/scanner_test.go` | Update `.skulto` in symlink target tests |
+| `internal/discovery/ingestion_test.go` | Update `.skulto` in test paths (global refs only) |
+| `internal/discovery/integration_test.go` | Update `.skulto` in test paths (global refs only) |
+| `internal/skillgen/executor_test.go` | Update `.skulto` in test paths and assertions |
+| `internal/tui/views/paths_test.go` | Update expected path: `~/.skulto/skills` → `~/.agents/skulto/skills` |
+
+## What Does NOT Change
+
+- **Project-local paths**: `./.skulto/skills` (relative to cwd) stays as-is
+- **Platform installation paths**: `~/.claude/skills/`, `~/.cursor/skills/`, etc. are unaffected
+- **Database schema**: No new columns or tables. Only a data-level UPDATE on `skills.file_path`
+- **Config loading**: `config.Load()` still reads env vars the same way
+- **`ensureDirectories()`**: Still creates `BaseDir` and `BaseDir/repositories` — just at the new path
+
+## File Inventory
+
+### Must Change (Code)
+1. `internal/config/paths.go` — DefaultBaseDir
+2. `internal/config/config.go` — call migrateBaseDir in Load
+3. `internal/config/migrate.go` — new file, migration logic
+4. `internal/vector/chromem.go` — fallback path
+5. `internal/skillgen/executor.go` — home skills dir
+6. `internal/discovery/scanner.go` — symlink target matching
+
+### Must Change (UI Strings)
+7. `internal/tui/components/quick_skill_dialog.go`
+8. `internal/tui/components/save_options_dialog.go`
+
+### Must Change (Tests)
+9. `internal/config/migrate_test.go` — new file
+10. `internal/installer/installer_test.go`
+11. `internal/discovery/scanner_test.go`
+12. `internal/discovery/ingestion_test.go`
+13. `internal/discovery/integration_test.go`
+14. `internal/skillgen/executor_test.go`
+15. `internal/tui/views/paths_test.go`
+
+### Must Change (Docs/Comments)
+16. `AGENTS.md`
+17. `README.md`
+18. `context/database.md`
+19. `context/platforms.md`
+20. `docs/getting-started.md`
+21. `docs/glossary.md`
+22. `docs/adr/0001-symlink-based-skill-installation.md`
+23. `docs/adr/0004-environment-variable-only-configuration.md`
+24. `docs/adr/0005-git-clone-over-github-api.md`
+25. Inline comments (~6 files listed in section 6)

--- a/internal/cli/favorites.go
+++ b/internal/cli/favorites.go
@@ -14,7 +14,7 @@ var favoritesCmd = &cobra.Command{
 	Short: "Manage favorite skills",
 	Long: `Manage your favorite skills.
 
-Favorites persist across database resets and are stored in ~/.skulto/favorites.json.
+Favorites persist across database resets and are stored in ~/.agents/skulto/favorites.json.
 
 Subcommands:
   add <slug>     Add a skill to favorites

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,11 +4,13 @@ package config
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/asteroid-belt/skulto/internal/log"
 )
 
 // Config holds all application configuration.
 type Config struct {
-	// Base directory for all Skulto data (~/.skulto)
+	// Base directory for all Skulto data (~/.agents/skulto)
 	BaseDir string
 
 	// GitHub API settings
@@ -49,7 +51,7 @@ type VectorConfig struct {
 	APIKey string
 	// Model for embeddings (default: text-embedding-3-small)
 	Model string
-	// DataDir for chromem-go persistence (default: ~/.skulto/vectors)
+	// DataDir for chromem-go persistence (default: ~/.agents/skulto/vectors)
 	DataDir string
 	// MinSimilarity threshold for search (default: 0.6)
 	MinSimilarity float32
@@ -61,7 +63,7 @@ type VectorConfig struct {
 func DefaultVectorConfig() VectorConfig {
 	return VectorConfig{
 		Model:         "text-embedding-3-small",
-		DataDir:       "", // Will use ~/.skulto/vectors
+		DataDir:       "", // Populated from BaseDir in Load()
 		MinSimilarity: 0.6,
 		Enabled:       false,
 	}
@@ -83,6 +85,21 @@ type GitHubConfig struct {
 func Load() (*Config, error) {
 	cfg := DefaultConfig()
 
+	// Migrate ~/.skulto → ~/.agents/skulto if needed (runs before ensureDirectories).
+	// Skip during testing to avoid migrating the real home directory.
+	if os.Getenv("SKULTO_SKIP_MIGRATION") == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			if err := migrateBaseDir(home); err != nil {
+				// Migration failed — fall back to old path for this session
+				oldDir := filepath.Join(home, ".skulto")
+				if _, statErr := os.Stat(oldDir); statErr == nil {
+					cfg.BaseDir = oldDir
+					log.Errorf("migrate: failed, using %s for this session: %v\n", oldDir, err)
+				}
+			}
+		}
+	}
+
 	// Read environment variables
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		cfg.GitHub.Token = token
@@ -100,6 +117,11 @@ func Load() (*Config, error) {
 
 	if apiKey := os.Getenv("OPENROUTER_API_KEY"); apiKey != "" {
 		cfg.LLM.OpenRouterAPIKey = apiKey
+	}
+
+	// Derive Embedding.DataDir from BaseDir if not explicitly set
+	if cfg.Embedding.DataDir == "" {
+		cfg.Embedding.DataDir = filepath.Join(cfg.BaseDir, "vectors")
 	}
 
 	// Ensure directories exist

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -17,6 +17,7 @@ func TestEmbeddingConfigDefaults(t *testing.T) {
 }
 
 func TestEmbeddingConfigFromEnv(t *testing.T) {
+	t.Setenv("SKULTO_SKIP_MIGRATION", "1")
 	// Save and restore original env
 	originalKey := os.Getenv("OPENAI_API_KEY")
 	defer func() {
@@ -47,6 +48,7 @@ func TestLLMConfigDefaults(t *testing.T) {
 }
 
 func TestLLMConfigFromEnv(t *testing.T) {
+	t.Setenv("SKULTO_SKIP_MIGRATION", "1")
 	// Save and restore original env
 	originalAnthropicKey := os.Getenv("ANTHROPIC_API_KEY")
 	originalOpenAIKey := os.Getenv("OPENAI_API_KEY")
@@ -90,6 +92,7 @@ func TestDefaultConfigIncludesLLM(t *testing.T) {
 }
 
 func TestGitHubTokenFromEnv(t *testing.T) {
+	t.Setenv("SKULTO_SKIP_MIGRATION", "1")
 	// Save and restore original env
 	originalToken := os.Getenv("GITHUB_TOKEN")
 	defer func() {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,292 @@
+package config
+
+import (
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/asteroid-belt/skulto/internal/log"
+)
+
+const migrationMarker = ".migration-complete"
+
+// migrateBaseDir moves ~/.skulto to ~/.agents/skulto if needed.
+// This runs once on startup before ensureDirectories().
+// Uses a .migration-complete marker file to track state safely.
+func migrateBaseDir(homeDir string) error {
+	oldDir := filepath.Join(homeDir, ".skulto")
+	newDir := filepath.Join(homeDir, ".agents", "skulto")
+	markerFile := filepath.Join(newDir, migrationMarker)
+
+	// 1. Does ~/.skulto exist (real dir, not symlink)?
+	info, err := os.Lstat(oldDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Fresh install
+		}
+		return fmt.Errorf("stat old dir: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil // Symlink or not a dir — skip
+	}
+
+	// 2. Was migration already completed in a prior run?
+	if _, err := os.Stat(markerFile); err == nil {
+		// Marker exists — prior migration succeeded.
+		// Do NOT delete ~/.skulto here. It may have been intentionally restored
+		// or contain new data. The old dir is harmless — it won't be used.
+		return nil
+	}
+
+	// 3. Move data to new location
+	if err := os.MkdirAll(filepath.Join(homeDir, ".agents"), 0755); err != nil {
+		return fmt.Errorf("create .agents dir: %w", err)
+	}
+
+	newIsEmpty := true
+	if contents, _ := dirHasContents(newDir); contents {
+		newIsEmpty = false
+	}
+
+	if newIsEmpty {
+		// Remove empty dir so os.Rename works
+		_ = os.RemoveAll(newDir)
+		if err := os.Rename(oldDir, newDir); err != nil {
+			// Cross-device fallback: copy + verify
+			if err := os.MkdirAll(newDir, 0755); err != nil {
+				return fmt.Errorf("create new dir: %w", err)
+			}
+			if err := copyDirContents(oldDir, newDir); err != nil {
+				return fmt.Errorf("copy migration: %w", err)
+			}
+			if err := verifyCriticalFiles(oldDir, newDir); err != nil {
+				return fmt.Errorf("verify migration: %w", err)
+			}
+		}
+	} else {
+		// Partial migration from prior attempt — copy missing contents
+		if err := copyDirContents(oldDir, newDir); err != nil {
+			return fmt.Errorf("complete partial migration: %w", err)
+		}
+	}
+
+	// 4. Post-move fixups (idempotent, safe to re-run)
+	dbPath := filepath.Join(newDir, "skulto.db")
+	if _, err := os.Stat(dbPath); err == nil {
+		if err := migrateDBPaths(dbPath); err != nil {
+			return fmt.Errorf("migrate DB paths: %w", err)
+		}
+	}
+
+	if err := rewriteSymlinks(dbPath, oldDir, newDir); err != nil {
+		return fmt.Errorf("rewrite symlinks: %w", err)
+	}
+
+	// 5. Write marker — signals migration completed successfully
+	if err := os.WriteFile(markerFile, []byte("migrated"), 0644); err != nil {
+		return fmt.Errorf("write migration marker: %w", err)
+	}
+
+	// 6. Remove old dir (safe — marker confirms success)
+	if err := os.RemoveAll(oldDir); err != nil {
+		log.Errorf("migrate: failed to remove old dir %s: %v\n", oldDir, err)
+	}
+
+	log.Printf("Migrated %s → %s\n", oldDir, newDir)
+	return nil
+}
+
+// migrateDBPaths updates absolute paths in the DB from /.skulto/ to /.agents/skulto/.
+// Returns nil if the DB can't be opened (e.g., corrupted) — non-fatal for migration.
+func migrateDBPaths(dbPath string) error {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		log.Errorf("migrate: could not open DB for path migration: %v\n", err)
+		return nil
+	}
+	defer func() { _ = db.Close() }()
+
+	// Verify it's actually a SQLite database before running queries
+	if err := db.Ping(); err != nil {
+		log.Errorf("migrate: DB ping failed, skipping path migration: %v\n", err)
+		return nil
+	}
+
+	_, err = db.Exec(
+		`UPDATE skills SET file_path = REPLACE(file_path, '/.skulto/', '/.agents/skulto/') WHERE file_path LIKE '%/.skulto/%'`,
+	)
+	if err != nil {
+		log.Errorf("migrate: failed to update skills paths: %v\n", err)
+		return nil
+	}
+	return nil
+}
+
+// rewriteSymlinks finds all symlinks on disk whose targets point into oldDir
+// and rewrites them to point into newDir. Uses the skill_installations DB table
+// to discover symlink locations across all platforms and scopes.
+func rewriteSymlinks(dbPath, oldDir, newDir string) error {
+	symlinkPaths, err := getInstalledSymlinkPaths(dbPath)
+	if err != nil {
+		log.Errorf("migrate: could not read skill_installations: %v\n", err)
+		return nil // Non-fatal — symlinks will be stale but not catastrophic
+	}
+
+	rewritten := 0
+	for _, linkPath := range symlinkPaths {
+		if rewriteOneSymlink(linkPath, oldDir, newDir) {
+			rewritten++
+		}
+	}
+
+	if rewritten > 0 {
+		log.Printf("Rewrote %d symlinks\n", rewritten)
+	}
+	return nil
+}
+
+// getInstalledSymlinkPaths reads all symlink_path values from skill_installations.
+func getInstalledSymlinkPaths(dbPath string) ([]string, error) {
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil, nil // No DB yet
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query("SELECT symlink_path FROM skill_installations WHERE symlink_path IS NOT NULL AND symlink_path != ''")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var paths []string
+	for rows.Next() {
+		var p string
+		if err := rows.Scan(&p); err != nil {
+			continue
+		}
+		paths = append(paths, p)
+	}
+	return paths, rows.Err()
+}
+
+// rewriteOneSymlink rewrites a single symlink if its target points into oldDir.
+func rewriteOneSymlink(linkPath, oldDir, newDir string) bool {
+	target, err := os.Readlink(linkPath)
+	if err != nil {
+		return false
+	}
+	if !strings.Contains(target, oldDir) {
+		return false
+	}
+	newTarget := strings.Replace(target, oldDir, newDir, 1)
+	if _, err := os.Stat(newTarget); err != nil {
+		return false // New target doesn't exist
+	}
+	if err := os.Remove(linkPath); err != nil {
+		log.Errorf("migrate: failed to remove symlink %s: %v\n", linkPath, err)
+		return false
+	}
+	if err := os.Symlink(newTarget, linkPath); err != nil {
+		log.Errorf("migrate: failed to create symlink %s → %s: %v\n", linkPath, newTarget, err)
+		return false
+	}
+	return true
+}
+
+// verifyCriticalFiles checks that user-data files were copied successfully.
+func verifyCriticalFiles(src, dst string) error {
+	if _, err := os.Stat(filepath.Join(src, "skulto.db")); err == nil {
+		if _, err := os.Stat(filepath.Join(dst, "skulto.db")); err != nil {
+			return fmt.Errorf("skulto.db missing from destination")
+		}
+	}
+	if _, err := os.Stat(filepath.Join(src, "favorites.json")); err == nil {
+		if _, err := os.Stat(filepath.Join(dst, "favorites.json")); err != nil {
+			return fmt.Errorf("favorites.json missing from destination")
+		}
+	}
+	srcSkills := filepath.Join(src, "skills")
+	dstSkills := filepath.Join(dst, "skills")
+	if srcEntries, err := os.ReadDir(srcSkills); err == nil {
+		dstEntries, err := os.ReadDir(dstSkills)
+		if err != nil {
+			return fmt.Errorf("skills/ dir missing from destination")
+		}
+		if len(srcEntries) != len(dstEntries) {
+			return fmt.Errorf("skills/ entry count mismatch: src=%d dst=%d", len(srcEntries), len(dstEntries))
+		}
+	}
+	return nil
+}
+
+// dirHasContents returns true if a directory has any entries.
+func dirHasContents(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, err
+	}
+	return len(entries) > 0, nil
+}
+
+// copyDirContents recursively copies all contents from src to dst.
+// Skips files that already exist at the destination (safe for partial recovery).
+func copyDirContents(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		dstPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(dstPath, info.Mode())
+		}
+
+		// Skip files that already exist
+		if _, err := os.Stat(dstPath); err == nil {
+			return nil
+		}
+
+		// Handle symlinks within the directory tree
+		if info.Mode()&os.ModeSymlink != 0 {
+			target, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(target, dstPath)
+		}
+
+		return copyFile(path, dstPath, info.Mode())
+	})
+}
+
+// copyFile copies a single file.
+func copyFile(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = out.Close() }()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,364 @@
+package config
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/glebarez/go-sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateBaseDir_FreshInstall(t *testing.T) {
+	home := t.TempDir()
+
+	err := migrateBaseDir(home)
+	require.NoError(t, err)
+
+	// Neither dir should exist (ensureDirectories handles creation later)
+	_, err = os.Stat(filepath.Join(home, ".skulto"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestMigrateBaseDir_AlreadyMigrated(t *testing.T) {
+	home := t.TempDir()
+
+	// ~/.agents/skulto has marker file from prior migration
+	newDir := filepath.Join(home, ".agents", "skulto")
+	require.NoError(t, os.MkdirAll(newDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(newDir, "skulto.db"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(newDir, migrationMarker), []byte("migrated"), 0644))
+
+	// ~/.skulto also exists (could be restored by user or leftover)
+	oldDir := filepath.Join(home, ".skulto")
+	require.NoError(t, os.MkdirAll(oldDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "skulto.db"), []byte("data"), 0644))
+
+	err := migrateBaseDir(home)
+	require.NoError(t, err)
+
+	// Old dir should NOT be removed — marker means migration is done,
+	// but we don't delete what might be user-restored data
+	_, err = os.Stat(oldDir)
+	assert.NoError(t, err)
+
+	// New dir still intact
+	_, err = os.Stat(filepath.Join(newDir, "skulto.db"))
+	assert.NoError(t, err)
+}
+
+func TestMigrateBaseDir_MovesData(t *testing.T) {
+	home := t.TempDir()
+
+	oldDir := filepath.Join(home, ".skulto")
+	require.NoError(t, os.MkdirAll(filepath.Join(oldDir, "repositories", "owner", "repo"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "skulto.db"), []byte("database"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "favorites.json"), []byte("{}"), 0644))
+
+	err := migrateBaseDir(home)
+	require.NoError(t, err)
+
+	newDir := filepath.Join(home, ".agents", "skulto")
+
+	// Old dir removed
+	_, err = os.Stat(oldDir)
+	assert.True(t, os.IsNotExist(err))
+
+	// Marker exists
+	_, err = os.Stat(filepath.Join(newDir, migrationMarker))
+	assert.NoError(t, err)
+
+	// Data present
+	data, err := os.ReadFile(filepath.Join(newDir, "skulto.db"))
+	require.NoError(t, err)
+	assert.Equal(t, "database", string(data))
+
+	data, err = os.ReadFile(filepath.Join(newDir, "favorites.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data))
+
+	// Nested dirs preserved
+	_, err = os.Stat(filepath.Join(newDir, "repositories", "owner", "repo"))
+	assert.NoError(t, err)
+}
+
+func TestMigrateBaseDir_SkipsSymlink(t *testing.T) {
+	home := t.TempDir()
+
+	realDir := filepath.Join(home, "real-skulto")
+	require.NoError(t, os.MkdirAll(realDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(realDir, "skulto.db"), []byte("data"), 0644))
+
+	oldDir := filepath.Join(home, ".skulto")
+	require.NoError(t, os.Symlink(realDir, oldDir))
+
+	err := migrateBaseDir(home)
+	require.NoError(t, err)
+
+	// Symlink should still exist (not removed or followed)
+	info, err := os.Lstat(oldDir)
+	require.NoError(t, err)
+	assert.True(t, info.Mode()&os.ModeSymlink != 0)
+}
+
+func TestMigrateBaseDir_PartialMigration(t *testing.T) {
+	home := t.TempDir()
+
+	// ~/.skulto has data
+	oldDir := filepath.Join(home, ".skulto")
+	require.NoError(t, os.MkdirAll(oldDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "skulto.db"), []byte("database"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(oldDir, "favorites.json"), []byte("{}"), 0644))
+
+	// ~/.agents/skulto exists with partial contents (no marker)
+	newDir := filepath.Join(home, ".agents", "skulto")
+	require.NoError(t, os.MkdirAll(newDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(newDir, "skulto.db"), []byte("database"), 0644))
+
+	err := migrateBaseDir(home)
+	require.NoError(t, err)
+
+	// Old dir removed
+	_, err = os.Stat(oldDir)
+	assert.True(t, os.IsNotExist(err))
+
+	// Missing file was copied
+	data, err := os.ReadFile(filepath.Join(newDir, "favorites.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data))
+
+	// Marker written
+	_, err = os.Stat(filepath.Join(newDir, migrationMarker))
+	assert.NoError(t, err)
+}
+
+func TestMigrateBaseDir_SymlinksRewritten(t *testing.T) {
+	home := t.TempDir()
+
+	// Create ~/.skulto with repo and DB
+	oldDir := filepath.Join(home, ".skulto")
+	repoDir := filepath.Join(oldDir, "repositories", "owner", "repo", "skills", "test-skill")
+	require.NoError(t, os.MkdirAll(repoDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "SKILL.md"), []byte("# test"), 0644))
+
+	// Create DB with skill_installations record
+	dbPath := filepath.Join(oldDir, "skulto.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE skills (id TEXT, file_path TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE skill_installations (id TEXT, skill_id TEXT NOT NULL, platform TEXT NOT NULL, scope TEXT NOT NULL, base_path TEXT NOT NULL, symlink_path TEXT, installed_at DATETIME)`)
+	require.NoError(t, err)
+	symlinkPath := filepath.Join(home, ".claude", "skills", "test-skill")
+	_, err = db.Exec(`INSERT INTO skill_installations (id, skill_id, platform, scope, base_path, symlink_path) VALUES (?, ?, ?, ?, ?, ?)`,
+		"test-id", "test-skill", "claude", "global", home, symlinkPath)
+	require.NoError(t, err)
+	_ = db.Close()
+
+	// Create platform symlink pointing into old dir
+	require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0755))
+	require.NoError(t, os.Symlink(repoDir, symlinkPath))
+
+	err = migrateBaseDir(home)
+	require.NoError(t, err)
+
+	// Old dir removed
+	_, err = os.Stat(oldDir)
+	assert.True(t, os.IsNotExist(err))
+
+	// Symlink now points to new location
+	target, err := os.Readlink(symlinkPath)
+	require.NoError(t, err)
+	assert.Contains(t, target, filepath.Join(".agents", "skulto"))
+	assert.NotContains(t, target, filepath.Join(home, ".skulto"))
+
+	// Symlink still resolves
+	_, err = os.Stat(filepath.Join(symlinkPath, "SKILL.md"))
+	assert.NoError(t, err)
+}
+
+func TestMigrateBaseDir_AllInstalledSkillsSurvive(t *testing.T) {
+	home := t.TempDir()
+	oldDir := filepath.Join(home, ".skulto")
+
+	// Create 3 repos with skill content
+	repos := []struct {
+		owner, repo, skill string
+	}{
+		{"asteroid-belt", "skills", "teach"},
+		{"asteroid-belt", "skills", "superbuild"},
+		{"other-org", "other-repo", "my-skill"},
+	}
+	for _, r := range repos {
+		dir := filepath.Join(oldDir, "repositories", r.owner, r.repo, "skills", r.skill)
+		require.NoError(t, os.MkdirAll(dir, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("# "+r.skill), 0644))
+	}
+
+	// Create DB
+	dbPath := filepath.Join(oldDir, "skulto.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE skills (id TEXT, file_path TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE skill_installations (id TEXT, skill_id TEXT NOT NULL, platform TEXT NOT NULL, scope TEXT NOT NULL, base_path TEXT NOT NULL, symlink_path TEXT, installed_at DATETIME)`)
+	require.NoError(t, err)
+
+	// Install skills across multiple platforms (global + project scope)
+	type install struct {
+		id, skillID, platform, scope, basePath string
+		repoOwner, repoName, skillSlug         string
+	}
+	projectDir := filepath.Join(home, "myproject")
+	installs := []install{
+		{"i1", "s1", "claude", "global", home, "asteroid-belt", "skills", "teach"},
+		{"i2", "s1", "codex", "global", home, "asteroid-belt", "skills", "teach"},
+		{"i3", "s2", "claude", "global", home, "asteroid-belt", "skills", "superbuild"},
+		{"i4", "s2", "roo", "global", home, "asteroid-belt", "skills", "superbuild"},
+		{"i5", "s3", "claude", "project", projectDir, "other-org", "other-repo", "my-skill"},
+	}
+
+	var symlinkPaths []string
+	for _, inst := range installs {
+		var skillsRel string
+		switch inst.platform {
+		case "claude":
+			skillsRel = ".claude/skills"
+		case "codex":
+			skillsRel = ".codex/skills"
+		case "roo":
+			skillsRel = ".roo/skills"
+		}
+		symlinkPath := filepath.Join(inst.basePath, skillsRel, inst.skillSlug)
+		symlinkPaths = append(symlinkPaths, symlinkPath)
+		_, err = db.Exec(`INSERT INTO skill_installations (id, skill_id, platform, scope, base_path, symlink_path) VALUES (?, ?, ?, ?, ?, ?)`,
+			inst.id, inst.skillID, inst.platform, inst.scope, inst.basePath, symlinkPath)
+		require.NoError(t, err)
+
+		// Create the actual symlink
+		repoDir := filepath.Join(oldDir, "repositories", inst.repoOwner, inst.repoName, "skills", inst.skillSlug)
+		require.NoError(t, os.MkdirAll(filepath.Dir(symlinkPath), 0755))
+		require.NoError(t, os.Symlink(repoDir, symlinkPath))
+	}
+	_ = db.Close()
+
+	// Verify pre-migration: all symlinks work
+	for _, sp := range symlinkPaths {
+		_, err := os.Stat(filepath.Join(sp, "SKILL.md"))
+		require.NoError(t, err, "pre-migration: symlink %s should resolve", sp)
+	}
+
+	// Run migration
+	err = migrateBaseDir(home)
+	require.NoError(t, err)
+
+	// Post-migration: every symlink still resolves
+	for _, sp := range symlinkPaths {
+		_, err := os.Stat(filepath.Join(sp, "SKILL.md"))
+		assert.NoError(t, err, "post-migration: symlink %s should still resolve", sp)
+	}
+
+	// Every symlink target points to new dir, not old
+	for _, sp := range symlinkPaths {
+		target, err := os.Readlink(sp)
+		require.NoError(t, err)
+		assert.Contains(t, target, filepath.Join(".agents", "skulto"),
+			"symlink %s should point to new dir", sp)
+		assert.NotContains(t, target, filepath.Join(home, ".skulto"),
+			"symlink %s should not point to old dir", sp)
+	}
+
+	// DB still has all installation records
+	newDB, err := sql.Open("sqlite", filepath.Join(home, ".agents", "skulto", "skulto.db"))
+	require.NoError(t, err)
+	defer func() { _ = newDB.Close() }()
+	var count int
+	err = newDB.QueryRow("SELECT COUNT(*) FROM skill_installations").Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, len(installs), count, "all installation records should survive migration")
+}
+
+func TestMigrateDBPaths(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "skulto.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`CREATE TABLE skills (id TEXT, file_path TEXT)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO skills (id, file_path) VALUES (?, ?)`,
+		"local-test", "/Users/test/.skulto/skills/test/skill.md")
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO skills (id, file_path) VALUES (?, ?)`,
+		"remote-test", "skills/remote/SKILL.md")
+	require.NoError(t, err)
+	// Path containing project name "skulto" — must NOT be rewritten
+	_, err = db.Exec(`INSERT INTO skills (id, file_path) VALUES (?, ?)`,
+		"project-test", "/Users/test/codes/skulto/.claude/skills/foo/SKILL.md")
+	require.NoError(t, err)
+
+	err = migrateDBPaths(dbPath)
+	require.NoError(t, err)
+
+	// Local path updated
+	var filePath string
+	err = db.QueryRow(`SELECT file_path FROM skills WHERE id = ?`, "local-test").Scan(&filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "/Users/test/.agents/skulto/skills/test/skill.md", filePath)
+
+	// Remote path NOT changed
+	err = db.QueryRow(`SELECT file_path FROM skills WHERE id = ?`, "remote-test").Scan(&filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "skills/remote/SKILL.md", filePath)
+
+	// Project path NOT changed (contains "skulto" but not "/.skulto/")
+	err = db.QueryRow(`SELECT file_path FROM skills WHERE id = ?`, "project-test").Scan(&filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "/Users/test/codes/skulto/.claude/skills/foo/SKILL.md", filePath)
+}
+
+func TestRewriteSymlinks(t *testing.T) {
+	home := t.TempDir()
+	oldDir := filepath.Join(home, ".skulto")
+	newDir := filepath.Join(home, ".agents", "skulto")
+
+	// Create target dirs
+	oldRepoDir := filepath.Join(oldDir, "repositories", "owner", "repo")
+	newRepoDir := filepath.Join(newDir, "repositories", "owner", "repo")
+	require.NoError(t, os.MkdirAll(oldRepoDir, 0755))
+	require.NoError(t, os.MkdirAll(newRepoDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(newRepoDir, "SKILL.md"), []byte("# skill"), 0644))
+
+	// Create symlink
+	claudeDir := filepath.Join(home, ".claude", "skills")
+	require.NoError(t, os.MkdirAll(claudeDir, 0755))
+	linkPath := filepath.Join(claudeDir, "my-skill")
+	require.NoError(t, os.Symlink(oldRepoDir, linkPath))
+
+	// Create DB with installation record
+	dbPath := filepath.Join(newDir, "skulto.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`CREATE TABLE skill_installations (id TEXT, skill_id TEXT NOT NULL, platform TEXT NOT NULL, scope TEXT NOT NULL, base_path TEXT NOT NULL, symlink_path TEXT, installed_at DATETIME)`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO skill_installations (id, skill_id, platform, scope, base_path, symlink_path) VALUES (?, ?, ?, ?, ?, ?)`,
+		"id1", "skill1", "claude", "global", home, linkPath)
+	require.NoError(t, err)
+	_ = db.Close()
+
+	err = rewriteSymlinks(dbPath, oldDir, newDir)
+	require.NoError(t, err)
+
+	// Symlink rewritten
+	target, err := os.Readlink(linkPath)
+	require.NoError(t, err)
+	assert.Contains(t, target, filepath.Join(".agents", "skulto"))
+	assert.NotContains(t, target, filepath.Join(home, ".skulto"))
+}
+
+func TestDefaultBaseDir_UsesAgentsDir(t *testing.T) {
+	dir := DefaultBaseDir()
+	assert.Contains(t, dir, filepath.Join(".agents", "skulto"))
+}

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -27,11 +27,11 @@ func GetPaths(cfg *Config) Paths {
 	}
 }
 
-// DefaultBaseDir returns the default base directory (~/.skulto).
+// DefaultBaseDir returns the default base directory (~/.agents/skulto).
 func DefaultBaseDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ".skulto"
+		return filepath.Join(".agents", "skulto")
 	}
-	return filepath.Join(home, ".skulto")
+	return filepath.Join(home, ".agents", "skulto")
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -130,6 +130,7 @@ func TestSkillCRUD(t *testing.T) {
 	}
 	if retrieved == nil {
 		t.Fatal("GetSkill() returned nil")
+		return
 	}
 	if retrieved.Title != "Test Skill" {
 		t.Errorf("Title = %q, want %q", retrieved.Title, "Test Skill")
@@ -183,6 +184,7 @@ func TestGetSkillBySlug(t *testing.T) {
 	}
 	if retrieved == nil {
 		t.Fatal("GetSkillBySlug() returned nil")
+		return
 	}
 	if retrieved.ID != "slug-test-001" {
 		t.Errorf("ID = %q, want %q", retrieved.ID, "slug-test-001")
@@ -350,6 +352,7 @@ func TestSourceCRUD(t *testing.T) {
 	}
 	if retrieved == nil {
 		t.Fatal("GetSource() returned nil")
+		return
 	}
 	if retrieved.Owner != "anthropics" {
 		t.Errorf("Owner = %q, want %q", retrieved.Owner, "anthropics")
@@ -450,6 +453,7 @@ func TestTagCRUD(t *testing.T) {
 	}
 	if retrieved == nil {
 		t.Fatal("GetTag() returned nil")
+		return
 	}
 	if retrieved.Name != "Python" {
 		t.Errorf("Name = %q, want %q", retrieved.Name, "Python")
@@ -1127,6 +1131,7 @@ func TestEnsureMineTag(t *testing.T) {
 	}
 	if tag == nil {
 		t.Fatal("mine tag should exist after DB init")
+		return
 	}
 	if tag.Priority != 100 {
 		t.Errorf("mine tag priority = %d, want 100", tag.Priority)
@@ -1157,6 +1162,7 @@ func TestMineTagCreatedOnStartup(t *testing.T) {
 	}
 	if tag == nil {
 		t.Fatal("mine tag should be created on DB init")
+		return
 	}
 	if tag.Priority != 100 {
 		t.Errorf("mine tag priority = %d, want 100", tag.Priority)

--- a/internal/discovery/ingestion_test.go
+++ b/internal/discovery/ingestion_test.go
@@ -82,7 +82,7 @@ func TestIngestionService_IngestSkill(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "skill.md"), []byte("# My Skill"), 0644))
 
 	// Create skulto destination directory
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	ds := models.DiscoveredSkill{
@@ -124,7 +124,7 @@ func TestIngestionService_IngestSkill_WithMultipleFiles(t *testing.T) {
 	require.NoError(t, os.MkdirAll(subDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(subDir, "template.txt"), []byte("template content"), 0644))
 
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	ds := models.DiscoveredSkill{
@@ -158,7 +158,7 @@ func TestIngestionService_IngestSkill_ValidationFailure(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sourceDir, 0755))
 	// No skill.md file
 
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	ds := models.DiscoveredSkill{
@@ -185,7 +185,7 @@ func TestIngestionService_IngestSkill_SymlinkPointsToDestination(t *testing.T) {
 	require.NoError(t, os.MkdirAll(sourceDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "skill.md"), []byte("# My Skill"), 0644))
 
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	ds := models.DiscoveredSkill{
@@ -255,7 +255,7 @@ This skill helps with Python development and testing.
 `
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "skill.md"), []byte(skillContent), 0644))
 
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	// Create test database
@@ -306,7 +306,7 @@ This skill tests installation record creation.
 `
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "skill.md"), []byte(skillContent), 0644))
 
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	// Create test database
@@ -356,7 +356,7 @@ Great for test-driven development workflows.
 `
 	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "skill.md"), []byte(skillContent), 0644))
 
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	database := testDB(t)

--- a/internal/discovery/integration_test.go
+++ b/internal/discovery/integration_test.go
@@ -56,7 +56,7 @@ func TestIntegration_ScanToIngest(t *testing.T) {
 	))
 
 	// Setup: Create skulto destination
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
 	// Step 1: Scan for unmanaged skills
@@ -116,7 +116,7 @@ func TestIntegration_RescanAfterIngest(t *testing.T) {
 
 	// Setup skill and ingest it
 	skillDir := filepath.Join(tmpDir, ".claude", "skills", "ingested-skill")
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skillDir, 0755))
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "skill.md"), []byte("# Test"), 0644))
@@ -224,7 +224,7 @@ func TestIntegration_ValidationFailure(t *testing.T) {
 
 	// Create skill without skill.md
 	skillDir := filepath.Join(tmpDir, ".claude", "skills", "invalid-skill")
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skillDir, 0755))
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 	// No skill.md file created
@@ -249,7 +249,7 @@ func TestIntegration_NameConflictCheck(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create skulto destination with existing skill
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	existingSkillDir := filepath.Join(skultoDir, "existing-skill")
 	require.NoError(t, os.MkdirAll(existingSkillDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(existingSkillDir, "skill.md"), []byte("# Existing"), 0644))
@@ -333,7 +333,7 @@ func TestIntegration_IngestWithDatabaseCleanup(t *testing.T) {
 
 	// Create skill
 	skillDir := filepath.Join(tmpDir, ".claude", "skills", "db-cleanup-skill")
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skillDir, 0755))
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "skill.md"), []byte("# DB Cleanup Test"), 0644))
@@ -375,7 +375,7 @@ func TestIntegration_MultipleFilesPreserved(t *testing.T) {
 
 	// Create skill with multiple files and subdirectories
 	skillDir := filepath.Join(tmpDir, ".claude", "skills", "complex-skill")
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skillDir, 0755))
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 
@@ -420,7 +420,7 @@ func TestIntegration_SymlinkCategorization(t *testing.T) {
 
 	// Setup: Create skulto-managed skill via ingestion
 	skillDir := filepath.Join(tmpDir, ".claude", "skills", "categorize-skill")
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skillDir, 0755))
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "skill.md"), []byte("# Categorize"), 0644))
@@ -523,7 +523,7 @@ func TestIntegration_EndToEndUserJourney(t *testing.T) {
 
 	// Step 1: User has manually created a skill
 	skillDir := filepath.Join(tmpDir, ".claude", "skills", "user-skill")
-	skultoDir := filepath.Join(tmpDir, ".skulto", "skills")
+	skultoDir := filepath.Join(tmpDir, ".agents", "skulto", "skills")
 	require.NoError(t, os.MkdirAll(skillDir, 0755))
 	require.NoError(t, os.MkdirAll(skultoDir, 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(skillDir, "skill.md"), []byte("# User Created Skill\n\nMy awesome skill."), 0644))

--- a/internal/discovery/scanner.go
+++ b/internal/discovery/scanner.go
@@ -112,14 +112,16 @@ func (s *ScannerService) CategorizeSymlink(path string) models.ManagementSource 
 
 // categorizeByTarget categorizes based on the symlink target path.
 func (s *ScannerService) categorizeByTarget(target string) models.ManagementSource {
-	// Check for skulto management (.skulto/skills/ or .skulto/repositories/)
-	if strings.Contains(target, ".skulto"+string(filepath.Separator)+"skills") ||
-		strings.Contains(target, ".skulto"+string(filepath.Separator)+"repositories") {
+	sep := string(filepath.Separator)
+	// Check for skulto management (new: .agents/skulto/ or legacy: .skulto/)
+	if strings.Contains(target, ".agents"+sep+"skulto"+sep) ||
+		strings.Contains(target, ".skulto"+sep+"skills") ||
+		strings.Contains(target, ".skulto"+sep+"repositories") {
 		return models.ManagementSkulto
 	}
 
 	// Check for Vercel management (~/.agents/skills/)
-	if strings.Contains(target, ".agents"+string(filepath.Separator)+"skills") {
+	if strings.Contains(target, ".agents"+sep+"skills") {
 		return models.ManagementVercel
 	}
 

--- a/internal/discovery/scanner_test.go
+++ b/internal/discovery/scanner_test.go
@@ -78,7 +78,24 @@ func TestScannerService_ScanDirectory_NonexistentDir(t *testing.T) {
 func TestScannerService_CategorizeSymlink_Skulto(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create skulto-managed symlink target
+	// Create skulto-managed symlink target (new path)
+	targetDir := filepath.Join(tmpDir, ".agents", "skulto", "repositories", "owner", "repo")
+	require.NoError(t, os.MkdirAll(targetDir, 0755))
+
+	// Create symlink
+	symlinkPath := filepath.Join(tmpDir, "link")
+	require.NoError(t, os.Symlink(targetDir, symlinkPath))
+
+	scanner := NewScannerService()
+	source := scanner.CategorizeSymlink(symlinkPath)
+
+	assert.Equal(t, models.ManagementSkulto, source)
+}
+
+func TestScannerService_CategorizeSymlink_SkultoLegacy(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create legacy skulto-managed symlink target
 	targetDir := filepath.Join(tmpDir, ".skulto", "skills", "my-skill")
 	require.NoError(t, os.MkdirAll(targetDir, 0755))
 

--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -218,7 +218,7 @@ func (i *Installer) InstallTo(ctx context.Context, skill *models.Skill, source *
 	return i.installToLocationsInternal(skill, sourcePath, locations)
 }
 
-// InstallLocalSkillTo installs a local skill (from ~/.skulto/skills) to specific locations.
+// InstallLocalSkillTo installs a local skill (from ~/.agents/skulto/skills) to specific locations.
 // Unlike InstallTo, this doesn't require a Source object since local skills are self-contained.
 func (i *Installer) InstallLocalSkillTo(ctx context.Context, skill *models.Skill, sourcePath string, locations []InstallLocation) error {
 	if skill == nil {

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -26,7 +26,7 @@ func setupTestDB(t *testing.T) *db.DB {
 // setupTestConfig creates a test config with temporary directories.
 func setupTestConfig(t *testing.T) *config.Config {
 	tmpDir := t.TempDir()
-	baseDir := filepath.Join(tmpDir, ".skulto")
+	baseDir := filepath.Join(tmpDir, ".agents", "skulto")
 	return &config.Config{
 		BaseDir: baseDir,
 	}

--- a/internal/installer/paths.go
+++ b/internal/installer/paths.go
@@ -25,7 +25,7 @@ func (pr *PathResolver) GetGlobalPath(platform Platform, skillSlug string) (stri
 
 // GetSourcePath returns the source path for a skill in its cloned repository.
 // Uses the skill's FilePath to determine the actual directory structure.
-// Example: ~/.skulto/repositories/owner/repo/skills/skill-slug/
+// Example: ~/.agents/skulto/repositories/owner/repo/skills/skill-slug/
 func (pr *PathResolver) GetSourcePath(owner, repo, skillFilePath string) string {
 	// skillFilePath is the path to SKILL.md (e.g., "skills/my-skill/SKILL.md")
 	// We need the parent directory (e.g., "skills/my-skill")

--- a/internal/llm/openai_test.go
+++ b/internal/llm/openai_test.go
@@ -37,6 +37,7 @@ func TestNewOpenAIProvider_ValidAPIKey(t *testing.T) {
 	}
 	if provider == nil {
 		t.Fatal("expected provider to be non-nil")
+		return
 	}
 	if provider.model != OpenAIDefaultModel {
 		t.Errorf("expected default model %q, got %q", OpenAIDefaultModel, provider.model)

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -28,6 +28,7 @@ func TestRead_FileExists(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("Read returned nil")
+		return
 	}
 	if got.Version != 1 {
 		t.Errorf("Version = %d, want 1", got.Version)

--- a/internal/scraper/git_client_test.go
+++ b/internal/scraper/git_client_test.go
@@ -12,6 +12,7 @@ func TestNewGitClient(t *testing.T) {
 
 	if client == nil {
 		t.Fatal("Expected non-nil GitClient")
+		return
 	}
 	if client.cache == nil {
 		t.Error("Expected non-nil cache")

--- a/internal/scraper/parser_test.go
+++ b/internal/scraper/parser_test.go
@@ -74,6 +74,7 @@ func TestNewSkillParser(t *testing.T) {
 	parser := NewSkillParser()
 	if parser == nil {
 		t.Fatal("NewSkillParser returned nil")
+		return
 	}
 	if parser.md == nil {
 		t.Fatal("Parser markdown instance is nil")

--- a/internal/scraper/repository_test.go
+++ b/internal/scraper/repository_test.go
@@ -54,6 +54,7 @@ func TestNewRepositoryManager(t *testing.T) {
 
 	if rm == nil {
 		t.Fatal("Expected non-nil RepositoryManager")
+		return
 	}
 	if rm.baseDir != baseDir {
 		t.Errorf("Expected baseDir %q, got %q", baseDir, rm.baseDir)

--- a/internal/scraper/scraper.go
+++ b/internal/scraper/scraper.go
@@ -57,7 +57,7 @@ type Client interface {
 // ScraperConfig holds configuration for the scraper.
 type ScraperConfig struct {
 	Token        string // GitHub token (optional for public repos with git clone)
-	DataDir      string // Base data directory (~/.skulto), repositories cloned to DataDir/repositories
+	DataDir      string // Base data directory (~/.agents/skulto), repositories cloned to DataDir/repositories
 	RepoCacheTTL int    // Days to keep cloned repos
 	UseGitClone  bool   // Use git clone instead of GitHub API
 }

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -374,6 +374,7 @@ func TestNewScraperWithConfigGitMode(t *testing.T) {
 	s := NewScraperWithConfig(cfg, nil)
 	if s == nil {
 		t.Fatal("Expected non-nil Scraper")
+		return
 	}
 
 	if s.gitClient == nil {
@@ -393,6 +394,7 @@ func TestNewScraperWithConfigAPIMode(t *testing.T) {
 	s := NewScraperWithConfig(cfg, nil)
 	if s == nil {
 		t.Fatal("Expected non-nil Scraper")
+		return
 	}
 
 	if s.gitClient != nil {
@@ -520,6 +522,7 @@ func TestScrapeSeedsWithOptionsCallsCorrectMethod(t *testing.T) {
 	// This is a structural test - verify the scraper was created correctly
 	if s == nil {
 		t.Fatal("Expected non-nil scraper")
+		return
 	}
 	if s.gitClient == nil {
 		t.Error("Expected gitClient to be set")

--- a/internal/security/context_test.go
+++ b/internal/security/context_test.go
@@ -9,6 +9,7 @@ func TestNewContextAnalyzer(t *testing.T) {
 
 	if ca == nil {
 		t.Fatal("NewContextAnalyzer() returned nil")
+		return
 	}
 
 	if ca.window != DefaultProximityWindow {
@@ -26,6 +27,7 @@ func TestNewContextAnalyzerWithWindow(t *testing.T) {
 
 	if ca == nil {
 		t.Fatal("NewContextAnalyzerWithWindow() returned nil")
+		return
 	}
 
 	if ca.window != customWindow {

--- a/internal/skillgen/executor.go
+++ b/internal/skillgen/executor.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/asteroid-belt/skulto/internal/config"
 	"github.com/asteroid-belt/skulto/internal/log"
 )
 
@@ -437,11 +438,7 @@ func (e *CLIExecutor) InteractiveCommand(tool AITool, userPrompt string) (*exec.
 
 // SkillsDir returns the skulto skills directory path.
 func SkillsDir() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(homeDir, ".skulto", "skills"), nil
+	return filepath.Join(config.DefaultBaseDir(), "skills"), nil
 }
 
 // SkillInfo represents basic info about a skill in the skills folder.

--- a/internal/skillgen/executor_test.go
+++ b/internal/skillgen/executor_test.go
@@ -166,7 +166,7 @@ func TestCLIExecutor_InteractiveCommand_ContainsAbsolutePath(t *testing.T) {
 	}
 
 	// Verify it does NOT contain ~ as a path reference
-	if strings.Contains(systemPrompt, "~/.skulto") {
+	if strings.Contains(systemPrompt, "~/.agents/skulto") {
 		t.Error("System prompt should not contain ~ as path, should use absolute path")
 	}
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -141,7 +141,7 @@ type (
 	pullCompleteMsg struct {
 		skillsFound int
 		skillsNew   int
-		localSynced int // Skills synced from ~/.skulto/skills
+		localSynced int // Skills synced from ~/.agents/skulto/skills
 		cwdSynced   int // Skills synced from ./.skulto/skills
 		err         error
 	}
@@ -423,7 +423,7 @@ func (m *Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{
 		m.tickCmd(),
 		m.loadDataCmd(),
-		m.syncLocalSkillsCmd(), // Sync ~/.skulto/skills on startup
+		m.syncLocalSkillsCmd(), // Sync ~/.agents/skulto/skills on startup
 		m.syncCwdSkillsCmd(),   // Sync ./.skulto/skills (cwd) on startup
 	}
 
@@ -1270,7 +1270,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 
 			// Always sync local skills when returning from Claude
-			// This ensures we catch any skills saved to ~/.skulto/skills
+			// This ensures we catch any skills saved to ~/.agents/skulto/skills
 			cmds = append(cmds, m.syncLocalSkillsCmd())
 		}
 
@@ -1617,7 +1617,7 @@ func (m *Model) syncCmd(githubToken string) tea.Cmd {
 			}
 		}
 
-		// Sync local skills from ~/.skulto/skills
+		// Sync local skills from ~/.agents/skulto/skills
 		localSynced := m.syncLocalSkillsInternal()
 
 		// Sync CWD skills from ./.skulto/skills
@@ -1633,7 +1633,7 @@ func (m *Model) syncCmd(githubToken string) tea.Cmd {
 	}
 }
 
-// syncLocalSkillsInternal syncs local skills from ~/.skulto/skills and returns the count.
+// syncLocalSkillsInternal syncs local skills from ~/.agents/skulto/skills and returns the count.
 func (m *Model) syncLocalSkillsInternal() int {
 	localSkills, err := skillgen.ScanSkills()
 	if err != nil || len(localSkills) == 0 {
@@ -1952,7 +1952,7 @@ func (m *Model) installBatchSkillsCmd(skills []models.Skill, locations []install
 	}
 }
 
-// syncLocalSkillsCmd returns a command that scans ~/.skulto/skills and indexes any skills
+// syncLocalSkillsCmd returns a command that scans ~/.agents/skulto/skills and indexes any skills
 // that exist on disk but are not in the database. This ensures local skills are always searchable.
 func (m *Model) syncLocalSkillsCmd() tea.Cmd {
 	return func() tea.Msg {
@@ -2425,7 +2425,7 @@ func (m *Model) saveManifestCmd() tea.Cmd {
 
 // saveNewSkillCmd returns a command to save the quick-generated skill.
 // Note: Legacy skill saving via skillbuilder has been removed.
-// Skills are now saved directly to ~/.skulto/skills by Claude.
+// Skills are now saved directly to ~/.agents/skulto/skills by Claude.
 func (m *Model) saveNewSkillCmd() tea.Cmd {
 	return func() tea.Msg {
 		return views.NewSkillSavedMsg{Err: fmt.Errorf("skill saving disabled - use Claude to save skills directly")}

--- a/internal/tui/components/quick_skill_dialog.go
+++ b/internal/tui/components/quick_skill_dialog.go
@@ -653,7 +653,7 @@ func (d *NewSkillDialog) viewLaunching() string {
 		lipgloss.NewStyle().Foreground(goldColor).Bold(true).Render("  Press Ctrl+C in the terminal"),
 		"",
 		instructTextStyle.Render("The AI will create your skill in:"),
-		lipgloss.NewStyle().Foreground(mutedColor).Italic(true).Render("  ~/.skulto/skills/<name>/skill.md"),
+		lipgloss.NewStyle().Foreground(mutedColor).Italic(true).Render("  ~/.agents/skulto/skills/<name>/skill.md"),
 	}
 
 	instructContent := lipgloss.JoinVertical(lipgloss.Center, append([]string{instructTitle}, instructLines...)...)
@@ -741,7 +741,7 @@ func (d *NewSkillDialog) viewGenerating() string {
 		Width(contentWidth).
 		Align(lipgloss.Center).
 		MarginTop(1)
-	footer := footerStyle.Render("Your skill will be saved to ~/.skulto/skills/")
+	footer := footerStyle.Render("Your skill will be saved to ~/.agents/skulto/skills/")
 
 	content := lipgloss.JoinVertical(
 		lipgloss.Left,
@@ -955,7 +955,7 @@ func (d *NewSkillDialog) viewResult() string {
 		Width(contentWidth).
 		Align(lipgloss.Center).
 		MarginTop(1)
-	hint := hintStyle.Render("Skills are saved to: ~/.skulto/skills/<name>/skill.md")
+	hint := hintStyle.Render("Skills are saved to: ~/.agents/skulto/skills/<name>/skill.md")
 
 	footerStyle := lipgloss.NewStyle().
 		Foreground(mutedColor).

--- a/internal/tui/components/save_options_dialog.go
+++ b/internal/tui/components/save_options_dialog.go
@@ -54,7 +54,7 @@ func NewSaveOptionsDialog() *SaveOptionsDialog {
 			{
 				Destination: SaveToFiles,
 				Title:       "Local Files Only",
-				Description: "Save to .skulto/skills/ as markdown files",
+				Description: "Save to .agents/skulto/skills/ as markdown files",
 				Icon:        "󰈙",
 			},
 		},

--- a/internal/tui/components/save_options_dialog_test.go
+++ b/internal/tui/components/save_options_dialog_test.go
@@ -12,6 +12,7 @@ func TestNewSaveOptionsDialog(t *testing.T) {
 
 	if dialog == nil {
 		t.Fatal("NewSaveOptionsDialog should not return nil")
+		return
 	}
 
 	// Should have 3 options

--- a/internal/tui/views/paths_test.go
+++ b/internal/tui/views/paths_test.go
@@ -26,8 +26,8 @@ func TestFormatPath(t *testing.T) {
 		},
 		{
 			name:     "path in home directory",
-			input:    filepath.Join(home, ".skulto", "skills"),
-			expected: "~/.skulto/skills",
+			input:    filepath.Join(home, ".agents", "skulto", "skills"),
+			expected: "~/.agents/skulto/skills",
 		},
 		{
 			name:     "home directory itself",

--- a/internal/tui/views/reset.go
+++ b/internal/tui/views/reset.go
@@ -141,7 +141,7 @@ func (v *ResetView) HandleResetComplete(msg ResetCompleteMsg) {
 
 // performResetAsync deletes all cached data for a clean slate.
 // This includes: symlinks, database, repositories, vectors, embeddings, and logs.
-// User skills in ~/.skulto/skills are preserved.
+// User skills in ~/.agents/skulto/skills are preserved.
 // This runs asynchronously in a goroutine to avoid blocking the TUI.
 // installations is passed in because the database is closed before this runs.
 func (v *ResetView) performResetAsync(installations []models.SkillInstallation) error {

--- a/internal/vector/chromem.go
+++ b/internal/vector/chromem.go
@@ -25,11 +25,11 @@ func NewChromemStore(cfg Config) (*ChromemStore, error) {
 		return nil, fmt.Errorf("OPENAI_API_KEY required for embeddings")
 	}
 
-	// Determine data directory
+	// Determine data directory (cfg.DataDir is populated from cfg.BaseDir in config.Load)
 	dataDir := cfg.DataDir
 	if dataDir == "" {
 		home, _ := os.UserHomeDir()
-		dataDir = filepath.Join(home, ".skulto", "vectors")
+		dataDir = filepath.Join(home, ".agents", "skulto", "vectors")
 	}
 
 	// Ensure directory exists

--- a/internal/vector/store.go
+++ b/internal/vector/store.go
@@ -40,7 +40,7 @@ type SearchHit struct {
 
 // Config holds vector store configuration.
 type Config struct {
-	// DataDir is where chromem-go persists vectors (default: ~/.skulto/vectors)
+	// DataDir is where chromem-go persists vectors (default: ~/.agents/skulto/vectors)
 	DataDir string
 
 	// OpenAI settings for embeddings


### PR DESCRIPTION
## Description

Complete migration of all references to ~/.skulto in favor of ~/.agents/skulto. Includes migration on first launch, fallback symlinks, and database migration of installed skills with local absolute paths (i.e. custom global skills).

## Type of Change

- [ ] New feature: adhering to the accepted ~/.agents standard. More enhancements to come. 

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] My code follows the project style guidelines
- [ ] I have added tests that prove my fix/feature works
- [ ] All new and existing tests pass (`make test`)
- [ ] The linter passes (`make lint`)
- [ ] I have updated documentation if needed

## Related Issues

Closes #(issue number)
